### PR TITLE
[HY-726] First take at adding EU location detection

### DIFF
--- a/lib/action_pack/cloudfront.rb
+++ b/lib/action_pack/cloudfront.rb
@@ -5,6 +5,7 @@ require 'timeout'
 require 'net/http'
 require 'action_pack/cloudfront/version'
 require 'action_pack/cloudfront/ip_ranges'
+require 'action_pack/cloudfront/eu_location_detection'
 require 'action_pack/cloudfront/railtie'
 
 module ActionPack

--- a/lib/action_pack/cloudfront.rb
+++ b/lib/action_pack/cloudfront.rb
@@ -5,7 +5,7 @@ require 'timeout'
 require 'net/http'
 require 'action_pack/cloudfront/version'
 require 'action_pack/cloudfront/ip_ranges'
-require 'action_pack/cloudfront/eu_location_detection'
+require 'action_pack/cloudfront/location_headers'
 require 'action_pack/cloudfront/railtie'
 
 module ActionPack

--- a/lib/action_pack/cloudfront/eu_location_detection.rb
+++ b/lib/action_pack/cloudfront/eu_location_detection.rb
@@ -7,7 +7,7 @@ module ActionPack
                               |RS|SK|SI|ES|SE|CH|UA|GB|VA|RS)$/ix
 
       def request_from_eu?
-        country_code = ActionDispatch::Http::Headers.new(request.headers)['CloudFront-Viewer-Country']
+        country_code = request.headers['CloudFront-Viewer-Country']
         country_code_in_eu?(country_code)
       end
 

--- a/lib/action_pack/cloudfront/eu_location_detection.rb
+++ b/lib/action_pack/cloudfront/eu_location_detection.rb
@@ -1,0 +1,21 @@
+module ActionPack
+  module Cloudfront
+    module EuLocationDetection
+      EU_ISO_3166_ALPHA_2 = /^(AL|AD|AT|BY|BE|BA|BG|HR|CY|CZ|DK|EE|FI
+                              |FR|DE|GI|GR|HU|IS|IE|IM|IT|RS|LV|LI|LT
+                              |LU|MK|MT|MD|MC|ME|NL|NO|PL|PT|RO|RU|SM
+                              |RS|SK|SI|ES|SE|CH|UA|GB|VA|RS)$/ix
+
+      def request_from_eu?
+        country_code = ActionDispatch::Http::Headers.new(request.headers)['CloudFront-Viewer-Country']
+        country_code_in_eu?(country_code)
+      end
+
+      private
+
+      def country_code_in_eu?(code)
+        !(code =~ EU_ISO_3166_ALPHA_2).nil?
+      end
+    end
+  end
+end

--- a/lib/action_pack/cloudfront/location_headers.rb
+++ b/lib/action_pack/cloudfront/location_headers.rb
@@ -1,20 +1,22 @@
 module ActionPack
   module Cloudfront
-    module EuLocationDetection
+    module LocationHeaders
+      extend ActiveSupport::Concern
+
       EU_ISO_3166_ALPHA_2 = /^(AL|AD|AT|BY|BE|BA|BG|HR|CY|CZ|DK|EE|FI
                               |FR|DE|GI|GR|HU|IS|IE|IM|IT|RS|LV|LI|LT
                               |LU|MK|MT|MD|MC|ME|NL|NO|PL|PT|RO|RU|SM
                               |RS|SK|SI|ES|SE|CH|UA|GB|VA|RS)$/ix
 
-      def request_from_eu?
-        country_code = request.headers['CloudFront-Viewer-Country']
-        country_code_in_eu?(country_code)
+      included do
+        helper_method :request_eu?
       end
 
       private
 
-      def country_code_in_eu?(code)
-        !(code =~ EU_ISO_3166_ALPHA_2).nil?
+      def request_eu?
+        country_code = request.headers['CloudFront-Viewer-Country']
+        !(country_code =~ EU_ISO_3166_ALPHA_2).nil?
       end
     end
   end

--- a/lib/action_pack/cloudfront/railtie.rb
+++ b/lib/action_pack/cloudfront/railtie.rb
@@ -15,7 +15,7 @@ module ActionPack
       end
 
       config.to_prepare do
-        ::ApplicationController.helper(ActionPack::Cloudfront::EuLocationDetection)
+        ::ApplicationController.send :include, ActionPack::Cloudfront::LocationHeaders
       end
 
     end

--- a/lib/action_pack/cloudfront/railtie.rb
+++ b/lib/action_pack/cloudfront/railtie.rb
@@ -14,6 +14,10 @@ module ActionPack
         end
       end
 
+      config.to_prepare do
+        ::ApplicationController.helper(ActionPack::Cloudfront::EuLocationDetection)
+      end
+
     end
   end
 end


### PR DESCRIPTION
This adds a helper `request_from_eu?` to any app including `actionpack-cloudfront`. It just looks at a regex of country codes and compares that to the `Cloudfront-Viewer-Country` header.

If this looks like an okay approach, I will add tests and Rollbar logging (when the header is empty).

Also I don't know a ton about the ip_ranges work already being done here and whether or not that code being active for all apps in production environment would be an issue.