### PR TITLE
Declare more specific dependencies

### DIFF
--- a/actionpack-cloudfront.gemspec
+++ b/actionpack-cloudfront.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency     'rails', '>= 4.2'
+  spec.add_runtime_dependency     'actionpack', '>= 4.2'
+  spec.add_runtime_dependency     'railties', '>= 4.2'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
### Description

This gem only depends on ActionPack and Railties, not all of Rails. The downside of having Rails as a dependency means all apps using this gem will be required to install ActiveRecord, ActionText, ActiveStorage, etc.

#### Why is this important?

- [ActiveStorage is a dependency of Rails.](https://github.com/rails/rails/blob/v6.1.3/rails.gemspec#L39)
- [Marcel is a dependency of ActiveStorage.](https://github.com/rails/rails/blob/v6.1.3/activestorage/activestorage.gemspec#L39)
- [MimeMagic is a dependency of Marcel.](https://github.com/rails/marcel/blob/v0.3.3/marcel.gemspec#L22)
- [freedesktop.org.xml is included as part of MimeMagic.](https://github.com/minad/mimemagic/blob/0.3.6/script/freedesktop.org.xml)
- [freedesktop.org.xml is licensed as GPL-2.0](https://github.com/minad/mimemagic/issues/97)

This means that any app or library using actionpack-cloudfront at the moment must also be GPL-2.0. Although this issue is currently being addressed by Rails and MimeMagic, apps trying to get around this issue by excluding ActiveStorage cannot due to the explicit dependency declared here.
```ruby
rails_version = "6.1.3"
# gem "rails",         rails_version
gem "activesupport", rails_version
gem "actionpack",    rails_version
gem "actionview",    rails_version
gem "activemodel",   rails_version
gem "activerecord",  rails_version
gem "actionmailer",  rails_version
gem "activejob",     rails_version
gem "actioncable",   rails_version
# gem "activestorage", rails_version # ❌ Still pulled in by actionpack-cloudfront
gem "actionmailbox", rails_version
gem "actiontext",    rails_version
gem "railties",      rails_version

gem "bundler",         ">= 1.15.0"
gem "sprockets-rails", ">= 2.0.0"
```