### PR TITLE
Append proxies instead of replacing

### DIFF
--- a/lib/action_pack/cloudfront/railtie.rb
+++ b/lib/action_pack/cloudfront/railtie.rb
@@ -10,7 +10,9 @@ module ActionPack
       config.before_initialize do |app|
         if app.config.action_pack_cloudfront.load_proxies
           trusted_proxies = ActionPack::Cloudfront::IpRanges.trusted_proxies
-          app.config.action_dispatch.trusted_proxies = trusted_proxies
+          existing_proxies = Array(app.config.action_dispatch.trusted_proxies)
+
+          app.config.action_dispatch.trusted_proxies = trusted_proxies.concat(existing_proxies).uniq
         end
       end
 


### PR DESCRIPTION
This change appends any existing proxies to the cloudfront proxies that are being added.

It also runs uniq so that we have a clean list.

Closes #16 