### PR TITLE
Remove unused abstract_unit require from test_helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,4 +9,3 @@ require 'rails/test_help'
 ap_path = Gem::Specification.find_all_by_name('actionpack').first.full_gem_path
 ap_test = File.join ap_path, 'test'
 $LOAD_PATH.unshift(ap_test)
-require 'abstract_unit'


### PR DESCRIPTION
This triggers some other loads such as capybara which doesn't work, since it's not part of the Gemfile.

### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_

Makes `bundle exec rake` run again.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_

- ✅ Negligible risk!

### Changes

Removes a require from the test helper.

##### Updated Dependencies
 - None
