### PR TITLE
LP-983/az/Update CloudFront IP ranges to 2026-07-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v1.2.18
+
+#### Changed
+
+- Updated CloudFront IP ranges
+
 ## v1.2.17
 
 #### Changed

--- a/lib/action_pack/cloudfront/ip-ranges.json
+++ b/lib/action_pack/cloudfront/ip-ranges.json
@@ -1,6 +1,6 @@
 {
-  "syncToken": "1782325025",
-  "createDate": "2026-06-24-18-17-05",
+  "syncToken": "1784711826",
+  "createDate": "2026-07-22-09-17-06",
   "prefixes": [
     {
       "ip_prefix": "3.4.12.4/32",
@@ -183,12 +183,6 @@
       "network_border_group": "GLOBAL"
     },
     {
-      "ip_prefix": "35.111.254.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "51.168.0.0/15",
       "region": "me-west-1",
       "service": "AMAZON",
@@ -369,6 +363,12 @@
       "network_border_group": "us-east-1-iah-1"
     },
     {
+      "ip_prefix": "3.4.12.80/32",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "3.5.60.0/22",
       "region": "ap-southeast-7",
       "service": "AMAZON",
@@ -445,6 +445,18 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "63.249.164.0/24",
+      "region": "ap-south-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-2"
+    },
+    {
+      "ip_prefix": "64.66.157.0/24",
+      "region": "ap-southeast-5",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-5"
     },
     {
       "ip_prefix": "96.0.80.0/22",
@@ -607,12 +619,6 @@
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
-    },
-    {
-      "ip_prefix": "35.96.248.0/24",
-      "region": "eu-west-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-2"
     },
     {
       "ip_prefix": "50.16.0.0/15",
@@ -879,6 +885,12 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ip_prefix": "63.249.129.0/24",
+      "region": "ap-southeast-6",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-6"
+    },
+    {
       "ip_prefix": "63.249.169.0/24",
       "region": "ap-northeast-2",
       "service": "AMAZON",
@@ -969,18 +981,6 @@
       "network_border_group": "eu-central-1"
     },
     {
-      "ip_prefix": "35.96.28.0/23",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.96.240.0/24",
-      "region": "ap-southeast-2",
-      "service": "AMAZON",
-      "network_border_group": "ap-southeast-2"
-    },
-    {
       "ip_prefix": "43.206.0.0/15",
       "region": "ap-northeast-1",
       "service": "AMAZON",
@@ -1033,6 +1033,12 @@
       "region": "ap-northeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-2"
+    },
+    {
+      "ip_prefix": "63.249.130.0/24",
+      "region": "ap-southeast-6",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-6"
     },
     {
       "ip_prefix": "64.73.207.0/24",
@@ -1237,6 +1243,12 @@
       "region": "ap-southeast-3",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-3"
+    },
+    {
+      "ip_prefix": "63.249.165.0/24",
+      "region": "ap-south-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-2"
     },
     {
       "ip_prefix": "150.222.52.224/27",
@@ -1563,6 +1575,12 @@
       "network_border_group": "us-west-1"
     },
     {
+      "ip_prefix": "63.249.173.0/24",
+      "region": "ap-southeast-5",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
       "ip_prefix": "69.107.11.48/29",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -1761,6 +1779,12 @@
       "network_border_group": "us-east-1-wl1-mia-wlz-1"
     },
     {
+      "ip_prefix": "1.178.168.0/24",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
+    },
+    {
       "ip_prefix": "5.60.64.0/19",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -1831,6 +1855,18 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "63.249.161.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-east-1"
+    },
+    {
+      "ip_prefix": "63.249.212.0/24",
+      "region": "cn-northwest-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-northwest-1"
     },
     {
       "ip_prefix": "69.107.9.184/29",
@@ -2101,6 +2137,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "63.249.213.0/24",
+      "region": "eu-central-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-2"
     },
     {
       "ip_prefix": "104.255.59.201/32",
@@ -2601,16 +2643,16 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ip_prefix": "35.111.252.0/24",
-      "region": "us-gov-west-1",
-      "service": "AMAZON",
-      "network_border_group": "us-gov-west-1"
-    },
-    {
       "ip_prefix": "45.33.170.0/24",
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "45.33.183.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "52.93.45.128/25",
@@ -2851,6 +2893,12 @@
       "region": "ap-southeast-4",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ip_prefix": "63.249.184.0/24",
+      "region": "eu-south-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "64.252.89.0/24",
@@ -3249,12 +3297,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ip_prefix": "35.96.11.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "52.46.252.0/22",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -3597,12 +3639,6 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ip_prefix": "35.96.60.0/23",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "52.93.24.0/21",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -3783,6 +3819,24 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "63.249.128.0/24",
+      "region": "ap-southeast-6",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-6"
+    },
+    {
+      "ip_prefix": "64.66.140.0/24",
+      "region": "ap-northeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "64.73.199.0/24",
+      "region": "us-gov-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
       "ip_prefix": "69.107.9.240/29",
       "region": "ap-northeast-1",
       "service": "AMAZON",
@@ -3915,6 +3969,12 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "63.249.147.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON",
+      "network_border_group": "af-south-1"
+    },
+    {
       "ip_prefix": "63.249.158.0/24",
       "region": "sa-east-1",
       "service": "AMAZON",
@@ -3987,6 +4047,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ip_prefix": "35.50.240.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ip_prefix": "35.71.94.0/24",
       "region": "eusc-de-east-1",
       "service": "AMAZON",
@@ -3997,12 +4063,6 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
-    },
-    {
-      "ip_prefix": "35.96.26.0/23",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "52.93.127.69/32",
@@ -4039,6 +4099,12 @@
       "region": "cn-north-1",
       "service": "AMAZON",
       "network_border_group": "cn-north-1"
+    },
+    {
+      "ip_prefix": "64.66.162.0/24",
+      "region": "ap-northeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-northeast-2"
     },
     {
       "ip_prefix": "64.252.72.0/24",
@@ -4413,12 +4479,6 @@
       "network_border_group": "eu-south-1"
     },
     {
-      "ip_prefix": "35.96.252.0/24",
-      "region": "ca-central-1",
-      "service": "AMAZON",
-      "network_border_group": "ca-central-1"
-    },
-    {
       "ip_prefix": "45.33.172.0/24",
       "region": "eu-west-1",
       "service": "AMAZON",
@@ -4521,12 +4581,6 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ip_prefix": "35.98.0.0/20",
-      "region": "eu-west-3",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-3"
-    },
-    {
       "ip_prefix": "52.93.20.0/24",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -4561,6 +4615,12 @@
       "region": "ap-south-1",
       "service": "AMAZON",
       "network_border_group": "ap-south-1"
+    },
+    {
+      "ip_prefix": "63.249.180.0/24",
+      "region": "ap-southeast-4",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ip_prefix": "150.222.112.0/24",
@@ -4711,6 +4771,12 @@
       "region": "ap-southeast-4",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ip_prefix": "63.249.160.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-east-1"
     },
     {
       "ip_prefix": "64.252.76.0/24",
@@ -4905,6 +4971,12 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "63.249.206.0/24",
+      "region": "ca-west-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-west-1"
+    },
+    {
       "ip_prefix": "64.187.128.0/20",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -5017,12 +5089,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "150.247.38.0/24",
-      "region": "eu-west-3",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "1.178.10.0/24",
@@ -5175,6 +5241,18 @@
       "network_border_group": "me-south-1"
     },
     {
+      "ip_prefix": "64.66.147.0/24",
+      "region": "eu-south-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-2"
+    },
+    {
+      "ip_prefix": "64.73.200.0/24",
+      "region": "us-gov-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
       "ip_prefix": "64.73.213.0/24",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -5271,6 +5349,12 @@
       "network_border_group": "cn-north-1"
     },
     {
+      "ip_prefix": "64.66.150.0/24",
+      "region": "ap-southeast-7",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-7"
+    },
+    {
       "ip_prefix": "99.77.56.0/21",
       "region": "ap-northeast-1",
       "service": "AMAZON",
@@ -5353,6 +5437,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "64.66.136.0/24",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "69.107.7.40/29",
@@ -5571,12 +5661,6 @@
       "network_border_group": "ap-south-1"
     },
     {
-      "ip_prefix": "35.97.16.0/20",
-      "region": "GLOBAL",
-      "service": "AMAZON",
-      "network_border_group": "GLOBAL"
-    },
-    {
       "ip_prefix": "35.176.0.0/15",
       "region": "eu-west-2",
       "service": "AMAZON",
@@ -5637,6 +5721,12 @@
       "network_border_group": "eu-central-1"
     },
     {
+      "ip_prefix": "3.4.12.76/32",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "15.221.6.0/24",
       "region": "sa-east-1",
       "service": "AMAZON",
@@ -5659,12 +5749,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.97.131.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "43.221.0.0/16",
@@ -5763,12 +5847,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ip_prefix": "35.111.136.0/22",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
-    },
-    {
       "ip_prefix": "51.20.0.0/16",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -5842,6 +5920,12 @@
     },
     {
       "ip_prefix": "104.255.56.65/32",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "104.255.56.70/32",
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
@@ -5973,6 +6057,12 @@
       "network_border_group": "us-west-1"
     },
     {
+      "ip_prefix": "150.247.38.0/27",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "1.178.93.0/24",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -6037,12 +6127,6 @@
       "region": "af-south-1",
       "service": "AMAZON",
       "network_border_group": "af-south-1"
-    },
-    {
-      "ip_prefix": "35.98.64.0/20",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "51.24.0.0/16",
@@ -6181,18 +6265,6 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
-    },
-    {
-      "ip_prefix": "35.96.1.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.41.0/24",
-      "region": "eu-central-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-2"
     },
     {
       "ip_prefix": "51.204.0.0/15",
@@ -6651,6 +6723,12 @@
       "network_border_group": "eu-south-1"
     },
     {
+      "ip_prefix": "63.249.162.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-east-1"
+    },
+    {
       "ip_prefix": "64.252.102.0/24",
       "region": "ap-southeast-1",
       "service": "AMAZON",
@@ -6745,12 +6823,6 @@
       "region": "ap-southeast-5",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-5"
-    },
-    {
-      "ip_prefix": "35.97.160.0/20",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "52.93.178.147/32",
@@ -6897,12 +6969,6 @@
       "network_border_group": "il-central-1"
     },
     {
-      "ip_prefix": "35.96.47.0/24",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ip_prefix": "52.93.178.179/32",
       "region": "us-west-1",
       "service": "AMAZON",
@@ -6985,6 +7051,12 @@
       "region": "us-east-2",
       "service": "AMAZON",
       "network_border_group": "us-east-2"
+    },
+    {
+      "ip_prefix": "23.254.26.0/23",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "51.45.0.0/16",
@@ -7365,18 +7437,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "35.96.7.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.34.0/24",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
-    },
-    {
       "ip_prefix": "52.93.122.202/32",
       "region": "sa-east-1",
       "service": "AMAZON",
@@ -7471,12 +7531,6 @@
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
-    },
-    {
-      "ip_prefix": "35.97.193.0/24",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "52.93.148.128/26",
@@ -7621,6 +7675,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "69.107.13.40/29",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "150.222.54.0/27",
@@ -7929,12 +7989,6 @@
       "network_border_group": "ap-southeast-1"
     },
     {
-      "ip_prefix": "35.97.129.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "35.160.0.0/13",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -8085,6 +8139,12 @@
       "network_border_group": "us-west-1"
     },
     {
+      "ip_prefix": "64.66.155.0/24",
+      "region": "mx-central-1",
+      "service": "AMAZON",
+      "network_border_group": "mx-central-1"
+    },
+    {
       "ip_prefix": "69.107.11.72/29",
       "region": "sa-east-1",
       "service": "AMAZON",
@@ -8139,6 +8199,12 @@
       "network_border_group": "ap-south-2"
     },
     {
+      "ip_prefix": "35.71.92.0/24",
+      "region": "me-west-1",
+      "service": "AMAZON",
+      "network_border_group": "me-west-1"
+    },
+    {
       "ip_prefix": "52.57.0.0/16",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -8167,6 +8233,12 @@
       "region": "ap-southeast-3",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-3"
+    },
+    {
+      "ip_prefix": "63.249.195.0/24",
+      "region": "il-central-1",
+      "service": "AMAZON",
+      "network_border_group": "il-central-1"
     },
     {
       "ip_prefix": "69.107.10.248/29",
@@ -8233,12 +8305,6 @@
       "region": "ca-west-1",
       "service": "AMAZON",
       "network_border_group": "ca-west-1"
-    },
-    {
-      "ip_prefix": "35.96.254.0/24",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "51.164.0.0/15",
@@ -8493,10 +8559,10 @@
       "network_border_group": "eu-west-1"
     },
     {
-      "ip_prefix": "35.96.12.0/24",
-      "region": "eu-central-1",
+      "ip_prefix": "45.33.181.0/24",
+      "region": "eu-west-2",
       "service": "AMAZON",
-      "network_border_group": "eu-central-1"
+      "network_border_group": "eu-west-2"
     },
     {
       "ip_prefix": "52.93.91.96/32",
@@ -8655,6 +8721,12 @@
       "network_border_group": "ca-west-1"
     },
     {
+      "ip_prefix": "64.66.160.0/24",
+      "region": "eu-west-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-2"
+    },
+    {
       "ip_prefix": "69.107.9.208/29",
       "region": "ap-southeast-2",
       "service": "AMAZON",
@@ -8713,18 +8785,6 @@
       "region": "us-west-1",
       "service": "AMAZON",
       "network_border_group": "us-west-1"
-    },
-    {
-      "ip_prefix": "35.96.128.0/20",
-      "region": "ap-southeast-2",
-      "service": "AMAZON",
-      "network_border_group": "ap-southeast-2"
-    },
-    {
-      "ip_prefix": "35.111.128.0/22",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "45.113.128.0/22",
@@ -8979,6 +9039,12 @@
       "network_border_group": "sa-east-1"
     },
     {
+      "ip_prefix": "150.222.56.0/27",
+      "region": "us-south-1",
+      "service": "AMAZON",
+      "network_border_group": "us-south-1"
+    },
+    {
       "ip_prefix": "151.148.37.0/24",
       "region": "ap-northeast-1",
       "service": "AMAZON",
@@ -9015,12 +9081,6 @@
       "network_border_group": "ap-southeast-1"
     },
     {
-      "ip_prefix": "35.96.46.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "51.0.128.0/21",
       "region": "eusc-de-east-1",
       "service": "AMAZON",
@@ -9055,6 +9115,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "64.66.134.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "64.73.202.0/24",
@@ -9141,7 +9207,7 @@
       "network_border_group": "me-central-1"
     },
     {
-      "ip_prefix": "35.96.39.0/24",
+      "ip_prefix": "35.50.242.0/24",
       "region": "ap-southeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-2"
@@ -9187,6 +9253,18 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "63.249.211.0/24",
+      "region": "cn-northwest-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-northwest-1"
+    },
+    {
+      "ip_prefix": "64.66.149.0/24",
+      "region": "ca-central-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-central-1"
     },
     {
       "ip_prefix": "69.107.12.240/29",
@@ -9327,6 +9405,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "69.107.13.32/29",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ip_prefix": "150.222.234.132/31",
       "region": "us-west-1",
       "service": "AMAZON",
@@ -9405,12 +9489,6 @@
       "network_border_group": "GLOBAL"
     },
     {
-      "ip_prefix": "35.96.96.0/20",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ip_prefix": "52.90.0.0/15",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -9469,6 +9547,12 @@
       "region": "ap-northeast-3",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-3"
+    },
+    {
+      "ip_prefix": "63.249.183.0/24",
+      "region": "eu-south-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "63.249.194.0/24",
@@ -9903,6 +9987,12 @@
       "network_border_group": "eu-south-1"
     },
     {
+      "ip_prefix": "64.73.198.0/24",
+      "region": "us-gov-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
       "ip_prefix": "83.119.128.0/18",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -9979,12 +10069,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.97.176.0/20",
-      "region": "sa-east-1",
-      "service": "AMAZON",
-      "network_border_group": "sa-east-1"
     },
     {
       "ip_prefix": "51.21.0.0/16",
@@ -10159,6 +10243,12 @@
       "region": "af-south-1",
       "service": "AMAZON",
       "network_border_group": "af-south-1"
+    },
+    {
+      "ip_prefix": "136.18.164.0/23",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "13.214.0.0/15",
@@ -10405,6 +10495,12 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "64.66.151.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON",
+      "network_border_group": "af-south-1"
     },
     {
       "ip_prefix": "103.8.172.0/22",
@@ -10671,6 +10767,12 @@
       "network_border_group": "eu-central-1"
     },
     {
+      "ip_prefix": "63.249.208.0/24",
+      "region": "eu-south-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-2"
+    },
+    {
       "ip_prefix": "65.9.128.0/18",
       "region": "GLOBAL",
       "service": "AMAZON",
@@ -10743,12 +10845,6 @@
       "network_border_group": "GLOBAL"
     },
     {
-      "ip_prefix": "35.96.45.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "43.204.0.0/15",
       "region": "ap-south-1",
       "service": "AMAZON",
@@ -10807,6 +10903,12 @@
       "region": "ap-southeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ip_prefix": "64.66.159.0/24",
+      "region": "sa-east-1",
+      "service": "AMAZON",
+      "network_border_group": "sa-east-1"
     },
     {
       "ip_prefix": "67.220.240.0/20",
@@ -10873,6 +10975,12 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "64.66.154.0/24",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "69.107.12.8/29",
@@ -11005,12 +11113,6 @@
       "region": "eu-north-1",
       "service": "AMAZON",
       "network_border_group": "eu-north-1"
-    },
-    {
-      "ip_prefix": "35.96.43.0/24",
-      "region": "sa-east-1",
-      "service": "AMAZON",
-      "network_border_group": "sa-east-1"
     },
     {
       "ip_prefix": "52.93.153.102/32",
@@ -11299,12 +11401,6 @@
       "region": "eu-west-3",
       "service": "AMAZON",
       "network_border_group": "eu-west-3"
-    },
-    {
-      "ip_prefix": "35.98.128.0/20",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "52.93.126.250/32",
@@ -11631,10 +11727,22 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ip_prefix": "63.249.149.0/24",
+      "region": "af-south-1",
+      "service": "AMAZON",
+      "network_border_group": "af-south-1"
+    },
+    {
       "ip_prefix": "63.249.207.0/24",
       "region": "eu-south-2",
       "service": "AMAZON",
       "network_border_group": "eu-south-2"
+    },
+    {
+      "ip_prefix": "63.249.210.0/24",
+      "region": "cn-northwest-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-northwest-1"
     },
     {
       "ip_prefix": "150.222.141.0/24",
@@ -12165,6 +12273,12 @@
       "network_border_group": "ap-south-1"
     },
     {
+      "ip_prefix": "3.4.14.0/29",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "3.5.76.0/22",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -12219,12 +12333,6 @@
       "network_border_group": "ap-southeast-2"
     },
     {
-      "ip_prefix": "35.96.22.0/23",
-      "region": "ca-central-1",
-      "service": "AMAZON",
-      "network_border_group": "ca-central-1"
-    },
-    {
       "ip_prefix": "52.93.133.155/32",
       "region": "eu-south-1",
       "service": "AMAZON",
@@ -12259,6 +12367,12 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1-mnl-1"
+    },
+    {
+      "ip_prefix": "150.247.38.112/28",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "3.4.15.176/29",
@@ -12531,12 +12645,6 @@
       "network_border_group": "ap-east-2"
     },
     {
-      "ip_prefix": "35.96.4.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "52.93.64.0/24",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -12655,18 +12763,6 @@
       "region": "us-east-2",
       "service": "AMAZON",
       "network_border_group": "us-east-2"
-    },
-    {
-      "ip_prefix": "35.97.144.0/20",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
-    },
-    {
-      "ip_prefix": "35.97.224.0/20",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "52.93.53.1/32",
@@ -12945,12 +13041,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "35.96.253.0/24",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ip_prefix": "51.96.0.0/16",
       "region": "eu-central-2",
       "service": "AMAZON",
@@ -13071,18 +13161,6 @@
       "network_border_group": "ap-northeast-2"
     },
     {
-      "ip_prefix": "35.96.6.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.35.0/24",
-      "region": "eu-west-3",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-3"
-    },
-    {
       "ip_prefix": "50.19.0.0/16",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -13185,12 +13263,6 @@
       "network_border_group": "GLOBAL"
     },
     {
-      "ip_prefix": "35.97.192.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "44.224.0.0/11",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -13243,6 +13315,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "150.222.55.192/27",
+      "region": "us-south-1",
+      "service": "AMAZON",
+      "network_border_group": "us-south-1"
     },
     {
       "ip_prefix": "150.222.104.0/24",
@@ -13327,12 +13405,6 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
-    },
-    {
-      "ip_prefix": "35.111.255.0/24",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "51.0.0.0/20",
@@ -13623,6 +13695,12 @@
       "network_border_group": "ap-northeast-2"
     },
     {
+      "ip_prefix": "64.66.156.0/24",
+      "region": "ap-east-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-east-1"
+    },
+    {
       "ip_prefix": "64.252.73.0/24",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -13711,12 +13789,6 @@
       "region": "ap-northeast-3",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-3"
-    },
-    {
-      "ip_prefix": "35.97.208.0/20",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "52.93.127.198/32",
@@ -13833,12 +13905,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "35.96.80.0/20",
-      "region": "eu-west-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-2"
-    },
-    {
       "ip_prefix": "43.194.0.0/20",
       "region": "cn-northwest-1",
       "service": "AMAZON",
@@ -13885,6 +13951,18 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "63.249.174.0/24",
+      "region": "ap-southeast-5",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
+      "ip_prefix": "64.66.138.0/24",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
     },
     {
       "ip_prefix": "96.0.12.0/22",
@@ -13971,12 +14049,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ip_prefix": "35.96.38.0/24",
-      "region": "ap-northeast-1",
-      "service": "AMAZON",
-      "network_border_group": "ap-northeast-1"
-    },
-    {
       "ip_prefix": "52.93.126.131/32",
       "region": "ap-southeast-2",
       "service": "AMAZON",
@@ -13999,6 +14071,18 @@
       "region": "eu-north-1",
       "service": "AMAZON",
       "network_border_group": "eu-north-1"
+    },
+    {
+      "ip_prefix": "63.249.189.0/24",
+      "region": "mx-central-1",
+      "service": "AMAZON",
+      "network_border_group": "mx-central-1"
+    },
+    {
+      "ip_prefix": "63.249.197.0/24",
+      "region": "il-central-1",
+      "service": "AMAZON",
+      "network_border_group": "il-central-1"
     },
     {
       "ip_prefix": "99.77.142.0/24",
@@ -14077,12 +14161,6 @@
       "region": "ap-northeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-2"
-    },
-    {
-      "ip_prefix": "35.96.48.0/21",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "46.51.216.0/21",
@@ -14221,24 +14299,6 @@
       "region": "ap-southeast-7",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-7"
-    },
-    {
-      "ip_prefix": "35.96.8.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.246.0/24",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
-    },
-    {
-      "ip_prefix": "35.97.128.0/24",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "43.249.44.0/24",
@@ -14565,6 +14625,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ip_prefix": "150.222.55.224/27",
+      "region": "us-south-1",
+      "service": "AMAZON",
+      "network_border_group": "us-south-1"
+    },
+    {
       "ip_prefix": "15.248.56.0/21",
       "region": "ap-southeast-5",
       "service": "AMAZON",
@@ -14593,12 +14659,6 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
-    },
-    {
-      "ip_prefix": "35.96.36.0/24",
-      "region": "eu-south-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "46.51.128.0/18",
@@ -15249,6 +15309,12 @@
       "network_border_group": "eu-north-1"
     },
     {
+      "ip_prefix": "64.66.130.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ip_prefix": "99.78.176.0/21",
       "region": "us-east-2",
       "service": "AMAZON",
@@ -15681,18 +15747,6 @@
       "network_border_group": "ap-southeast-3"
     },
     {
-      "ip_prefix": "35.96.32.0/24",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.97.0.0/20",
-      "region": "GLOBAL",
-      "service": "AMAZON",
-      "network_border_group": "GLOBAL"
-    },
-    {
       "ip_prefix": "52.93.229.96/32",
       "region": "eu-west-2",
       "service": "AMAZON",
@@ -15843,6 +15897,12 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "63.249.190.0/24",
+      "region": "mx-central-1",
+      "service": "AMAZON",
+      "network_border_group": "mx-central-1"
+    },
+    {
       "ip_prefix": "69.107.7.128/29",
       "region": "me-south-1",
       "service": "AMAZON",
@@ -15925,6 +15985,12 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ip_prefix": "35.128.128.0/18",
+      "region": "us-south-1",
+      "service": "AMAZON",
+      "network_border_group": "us-south-1"
     },
     {
       "ip_prefix": "52.93.84.162/32",
@@ -16161,6 +16227,12 @@
       "network_border_group": "ap-east-1"
     },
     {
+      "ip_prefix": "3.4.12.79/32",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "15.230.39.74/31",
       "region": "us-east-2",
       "service": "AMAZON",
@@ -16243,6 +16315,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "64.66.152.0/24",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
     },
     {
       "ip_prefix": "64.73.211.0/24",
@@ -16513,12 +16591,6 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
-    },
-    {
-      "ip_prefix": "35.98.96.0/20",
-      "region": "sa-east-1",
-      "service": "AMAZON",
-      "network_border_group": "sa-east-1"
     },
     {
       "ip_prefix": "52.36.0.0/14",
@@ -16947,10 +17019,22 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "54.115.0.0/16",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
+    },
+    {
       "ip_prefix": "54.215.0.0/16",
       "region": "us-west-1",
       "service": "AMAZON",
       "network_border_group": "us-west-1"
+    },
+    {
+      "ip_prefix": "64.66.158.0/24",
+      "region": "eu-south-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "150.222.226.0/24",
@@ -16987,18 +17071,6 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
-    },
-    {
-      "ip_prefix": "35.96.24.0/23",
-      "region": "eu-west-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-2"
-    },
-    {
-      "ip_prefix": "35.96.242.0/24",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "43.218.0.0/16",
@@ -17307,10 +17379,10 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ip_prefix": "35.97.194.0/24",
-      "region": "eu-west-1",
+      "ip_prefix": "40.235.128.0/18",
+      "region": "us-south-1",
       "service": "AMAZON",
-      "network_border_group": "eu-west-1"
+      "network_border_group": "us-south-1"
     },
     {
       "ip_prefix": "52.70.0.0/15",
@@ -17491,6 +17563,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "64.66.161.0/24",
+      "region": "ap-south-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-2"
     },
     {
       "ip_prefix": "64.73.210.0/24",
@@ -18033,6 +18111,12 @@
       "network_border_group": "eu-south-1"
     },
     {
+      "ip_prefix": "63.249.136.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-north-1"
+    },
+    {
       "ip_prefix": "69.107.11.8/29",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -18229,6 +18313,12 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "63.249.199.0/24",
+      "region": "ap-east-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-east-2"
     },
     {
       "ip_prefix": "64.252.83.0/24",
@@ -18501,10 +18591,16 @@
       "network_border_group": "ap-southeast-3"
     },
     {
-      "ip_prefix": "64.73.193.0/24",
-      "region": "us-east-1",
+      "ip_prefix": "64.66.144.0/24",
+      "region": "eu-central-2",
       "service": "AMAZON",
-      "network_border_group": "us-east-1"
+      "network_border_group": "eu-central-2"
+    },
+    {
+      "ip_prefix": "64.73.193.0/24",
+      "region": "us-gov-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-west-1"
     },
     {
       "ip_prefix": "76.162.0.0/15",
@@ -18625,6 +18721,12 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "64.66.131.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "64.252.100.0/24",
@@ -18927,12 +19029,6 @@
       "network_border_group": "eu-north-1"
     },
     {
-      "ip_prefix": "35.96.58.0/23",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ip_prefix": "45.33.169.0/24",
       "region": "ap-northeast-2",
       "service": "AMAZON",
@@ -18973,6 +19069,12 @@
       "region": "eu-west-3",
       "service": "AMAZON",
       "network_border_group": "eu-west-3"
+    },
+    {
+      "ip_prefix": "63.249.179.0/24",
+      "region": "ap-southeast-4",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ip_prefix": "69.107.12.216/29",
@@ -19167,6 +19269,12 @@
       "network_border_group": "eu-west-2"
     },
     {
+      "ip_prefix": "3.4.12.75/32",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "3.4.15.248/29",
       "region": "ap-northeast-2",
       "service": "AMAZON",
@@ -19299,6 +19407,12 @@
       "network_border_group": "ca-west-1"
     },
     {
+      "ip_prefix": "63.249.205.0/24",
+      "region": "ca-west-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-west-1"
+    },
+    {
       "ip_prefix": "89.60.0.0/15",
       "region": "eu-south-2",
       "service": "AMAZON",
@@ -19363,18 +19477,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.96.112.0/20",
-      "region": "eu-south-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-south-1"
-    },
-    {
-      "ip_prefix": "35.96.251.0/24",
-      "region": "ca-west-1",
-      "service": "AMAZON",
-      "network_border_group": "ca-west-1"
     },
     {
       "ip_prefix": "35.178.0.0/15",
@@ -19485,12 +19587,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ip_prefix": "35.97.240.0/20",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
-    },
-    {
       "ip_prefix": "51.0.96.0/21",
       "region": "eu-west-3",
       "service": "AMAZON",
@@ -19513,6 +19609,12 @@
       "region": "eu-north-1",
       "service": "AMAZON",
       "network_border_group": "eu-north-1"
+    },
+    {
+      "ip_prefix": "64.66.128.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "64.252.119.0/24",
@@ -19705,6 +19807,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "64.66.142.0/24",
+      "region": "ap-southeast-4",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ip_prefix": "64.73.216.0/24",
@@ -19953,6 +20061,12 @@
       "network_border_group": "eu-north-1"
     },
     {
+      "ip_prefix": "64.66.133.0/24",
+      "region": "ap-northeast-3",
+      "service": "AMAZON",
+      "network_border_group": "ap-northeast-3"
+    },
+    {
       "ip_prefix": "64.252.104.0/24",
       "region": "ap-southeast-1",
       "service": "AMAZON",
@@ -19987,6 +20101,12 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "5.60.48.0/20",
+      "region": "us-south-1",
+      "service": "AMAZON",
+      "network_border_group": "us-south-1"
     },
     {
       "ip_prefix": "13.54.0.0/15",
@@ -20053,12 +20173,6 @@
       "region": "us-gov-east-1",
       "service": "AMAZON",
       "network_border_group": "us-gov-east-1"
-    },
-    {
-      "ip_prefix": "35.96.40.0/24",
-      "region": "af-south-1",
-      "service": "AMAZON",
-      "network_border_group": "af-south-1"
     },
     {
       "ip_prefix": "52.93.193.202/32",
@@ -20217,12 +20331,6 @@
       "network_border_group": "eu-west-2"
     },
     {
-      "ip_prefix": "35.96.44.0/24",
-      "region": "ca-west-1",
-      "service": "AMAZON",
-      "network_border_group": "ca-west-1"
-    },
-    {
       "ip_prefix": "36.103.232.128/26",
       "region": "GLOBAL",
       "service": "AMAZON",
@@ -20293,6 +20401,12 @@
       "region": "ap-southeast-3",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-3"
+    },
+    {
+      "ip_prefix": "64.66.148.0/24",
+      "region": "il-central-1",
+      "service": "AMAZON",
+      "network_border_group": "il-central-1"
     },
     {
       "ip_prefix": "69.107.10.32/29",
@@ -20739,6 +20853,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "64.66.137.0/24",
+      "region": "us-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-west-1"
+    },
+    {
       "ip_prefix": "99.78.168.0/23",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -21003,6 +21123,12 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ip_prefix": "63.249.137.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-north-1"
+    },
+    {
       "ip_prefix": "94.38.0.0/15",
       "region": "ap-southeast-5",
       "service": "AMAZON",
@@ -21129,6 +21255,12 @@
       "network_border_group": "ap-southeast-1"
     },
     {
+      "ip_prefix": "63.249.163.0/24",
+      "region": "ap-south-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-2"
+    },
+    {
       "ip_prefix": "69.107.7.0/29",
       "region": "ap-southeast-1",
       "service": "AMAZON",
@@ -21183,12 +21315,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ip_prefix": "35.98.48.0/20",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
-    },
-    {
       "ip_prefix": "52.46.180.0/22",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -21223,6 +21349,18 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "64.66.153.0/24",
+      "region": "ap-southeast-3",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-3"
+    },
+    {
+      "ip_prefix": "64.73.194.0/24",
+      "region": "us-gov-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-west-1"
     },
     {
       "ip_prefix": "69.107.7.112/29",
@@ -21603,6 +21741,12 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ip_prefix": "23.254.28.0/23",
+      "region": "us-south-1",
+      "service": "AMAZON",
+      "network_border_group": "us-south-1"
+    },
+    {
       "ip_prefix": "52.93.127.95/32",
       "region": "cn-northwest-1",
       "service": "AMAZON",
@@ -21843,6 +21987,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ip_prefix": "35.50.241.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ip_prefix": "35.55.41.0/24",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -21853,6 +22003,12 @@
       "region": "ap-east-1",
       "service": "AMAZON",
       "network_border_group": "ap-east-1"
+    },
+    {
+      "ip_prefix": "45.33.184.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "52.66.0.0/16",
@@ -21961,12 +22117,6 @@
       "region": "mx-central-1",
       "service": "AMAZON",
       "network_border_group": "mx-central-1"
-    },
-    {
-      "ip_prefix": "35.96.16.0/23",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "35.168.0.0/13",
@@ -22257,12 +22407,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "35.96.33.0/24",
-      "region": "us-west-1",
-      "service": "AMAZON",
-      "network_border_group": "us-west-1"
-    },
-    {
       "ip_prefix": "52.92.0.0/17",
       "region": "eu-west-1",
       "service": "AMAZON",
@@ -22297,6 +22441,12 @@
       "region": "eu-north-1",
       "service": "AMAZON",
       "network_border_group": "eu-north-1"
+    },
+    {
+      "ip_prefix": "63.249.143.0/24",
+      "region": "ap-southeast-3",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-3"
     },
     {
       "ip_prefix": "99.150.112.0/21",
@@ -22432,9 +22582,9 @@
     },
     {
       "ip_prefix": "1.178.86.0/24",
-      "region": "us-east-2",
+      "region": "ap-southeast-3",
       "service": "AMAZON",
-      "network_border_group": "us-east-2"
+      "network_border_group": "ap-southeast-3"
     },
     {
       "ip_prefix": "1.178.172.0/23",
@@ -22471,12 +22621,6 @@
       "region": "ap-south-1",
       "service": "AMAZON",
       "network_border_group": "ap-south-1"
-    },
-    {
-      "ip_prefix": "35.96.5.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "45.57.128.0/18",
@@ -22585,12 +22729,6 @@
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
-    },
-    {
-      "ip_prefix": "35.96.244.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "52.93.90.163/32",
@@ -22893,6 +23031,12 @@
       "network_border_group": "ap-southeast-3"
     },
     {
+      "ip_prefix": "63.249.191.0/24",
+      "region": "mx-central-1",
+      "service": "AMAZON",
+      "network_border_group": "mx-central-1"
+    },
+    {
       "ip_prefix": "120.232.236.0/25",
       "region": "GLOBAL",
       "service": "AMAZON",
@@ -22963,12 +23107,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.98.32.0/20",
-      "region": "ca-central-1",
-      "service": "AMAZON",
-      "network_border_group": "ca-central-1"
     },
     {
       "ip_prefix": "52.93.92.0/24",
@@ -23233,6 +23371,12 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "45.33.186.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "52.93.91.98/32",
@@ -23601,6 +23745,12 @@
       "network_border_group": "ap-southeast-1"
     },
     {
+      "ip_prefix": "3.4.12.77/32",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "3.5.80.0/21",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -23925,6 +24075,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "63.249.141.0/24",
+      "region": "ap-southeast-3",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-3"
+    },
+    {
       "ip_prefix": "99.77.163.0/24",
       "region": "il-central-1",
       "service": "AMAZON",
@@ -24025,6 +24181,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "64.66.143.0/24",
+      "region": "ap-southeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-1"
     },
     {
       "ip_prefix": "76.223.170.144/28",
@@ -24169,6 +24331,12 @@
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
+    },
+    {
+      "ip_prefix": "64.66.141.0/24",
+      "region": "eu-north-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-north-1"
     },
     {
       "ip_prefix": "99.77.24.0/22",
@@ -24457,18 +24625,6 @@
       "region": "us-east-2",
       "service": "AMAZON",
       "network_border_group": "us-east-2"
-    },
-    {
-      "ip_prefix": "35.98.80.0/20",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.111.253.0/24",
-      "region": "us-gov-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-gov-east-1"
     },
     {
       "ip_prefix": "40.164.0.0/16",
@@ -24987,12 +25143,6 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ip_prefix": "35.96.2.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "35.154.0.0/16",
       "region": "ap-south-1",
       "service": "AMAZON",
@@ -25149,6 +25299,12 @@
       "network_border_group": "ap-east-1"
     },
     {
+      "ip_prefix": "45.33.185.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ip_prefix": "52.93.149.0/24",
       "region": "us-west-1",
       "service": "AMAZON",
@@ -25195,6 +25351,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "63.249.209.0/24",
+      "region": "eu-south-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-2"
     },
     {
       "ip_prefix": "76.223.0.0/17",
@@ -25515,6 +25677,12 @@
       "network_border_group": "eu-south-2"
     },
     {
+      "ip_prefix": "45.33.182.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ip_prefix": "51.202.0.0/15",
       "region": "eu-west-2",
       "service": "AMAZON",
@@ -25645,18 +25813,6 @@
       "region": "us-gov-east-1",
       "service": "AMAZON",
       "network_border_group": "us-gov-east-1"
-    },
-    {
-      "ip_prefix": "35.96.10.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.56.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "43.193.65.0/24",
@@ -25855,12 +26011,6 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
-    },
-    {
-      "ip_prefix": "35.96.255.0/24",
-      "region": "us-west-1",
-      "service": "AMAZON",
-      "network_border_group": "us-west-1"
     },
     {
       "ip_prefix": "52.93.33.9/32",
@@ -26113,6 +26263,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "63.249.134.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-north-1"
     },
     {
       "ip_prefix": "69.107.9.192/29",
@@ -26433,12 +26589,6 @@
       "network_border_group": "ca-west-1"
     },
     {
-      "ip_prefix": "35.96.241.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "43.196.0.0/16",
       "region": "cn-north-1",
       "service": "AMAZON",
@@ -26563,24 +26713,6 @@
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
-    },
-    {
-      "ip_prefix": "35.96.37.0/24",
-      "region": "eu-south-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-south-2"
-    },
-    {
-      "ip_prefix": "35.96.243.0/24",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
-    },
-    {
-      "ip_prefix": "35.98.112.0/20",
-      "region": "sa-east-1",
-      "service": "AMAZON",
-      "network_border_group": "sa-east-1"
     },
     {
       "ip_prefix": "43.249.46.0/24",
@@ -26851,12 +26983,6 @@
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
-    },
-    {
-      "ip_prefix": "35.96.144.0/20",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "52.93.66.0/24",
@@ -27147,6 +27273,12 @@
       "network_border_group": "eu-west-3"
     },
     {
+      "ip_prefix": "63.249.214.0/24",
+      "region": "eu-central-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-2"
+    },
+    {
       "ip_prefix": "69.107.10.0/29",
       "region": "us-west-1",
       "service": "AMAZON",
@@ -27205,6 +27337,12 @@
       "region": "us-west-1",
       "service": "AMAZON",
       "network_border_group": "us-west-1"
+    },
+    {
+      "ip_prefix": "35.50.145.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "35.71.101.0/24",
@@ -27355,12 +27493,6 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
-    },
-    {
-      "ip_prefix": "35.98.16.0/20",
-      "region": "eu-west-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-2"
     },
     {
       "ip_prefix": "51.0.24.0/22",
@@ -27519,12 +27651,6 @@
       "network_border_group": "ap-east-1"
     },
     {
-      "ip_prefix": "35.96.15.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "52.93.51.0/24",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -27613,6 +27739,12 @@
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
+    },
+    {
+      "ip_prefix": "3.4.14.8/29",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "16.182.0.0/16",
@@ -27903,6 +28035,12 @@
       "network_border_group": "eu-central-1"
     },
     {
+      "ip_prefix": "63.249.175.0/24",
+      "region": "ap-southeast-5",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
       "ip_prefix": "63.249.215.0/24",
       "region": "eu-central-2",
       "service": "AMAZON",
@@ -28003,6 +28141,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "64.66.146.0/24",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ip_prefix": "64.252.77.0/24",
@@ -28185,12 +28329,6 @@
       "network_border_group": "sa-east-1"
     },
     {
-      "ip_prefix": "35.96.14.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "40.180.0.0/15",
       "region": "eu-west-1",
       "service": "AMAZON",
@@ -28269,18 +28407,6 @@
       "network_border_group": "GLOBAL"
     },
     {
-      "ip_prefix": "35.96.64.0/20",
-      "region": "eu-west-3",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-3"
-    },
-    {
-      "ip_prefix": "35.96.245.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "43.208.0.0/15",
       "region": "ap-southeast-7",
       "service": "AMAZON",
@@ -28311,10 +28437,22 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "63.249.135.0/24",
+      "region": "cn-north-1",
+      "service": "AMAZON",
+      "network_border_group": "cn-north-1"
+    },
+    {
       "ip_prefix": "63.249.178.0/24",
       "region": "eu-west-2",
       "service": "AMAZON",
       "network_border_group": "eu-west-2"
+    },
+    {
+      "ip_prefix": "64.66.139.0/24",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "108.166.244.55/32",
@@ -28519,12 +28657,6 @@
       "region": "ap-south-2",
       "service": "AMAZON",
       "network_border_group": "ap-south-2"
-    },
-    {
-      "ip_prefix": "35.97.130.0/24",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
     },
     {
       "ip_prefix": "52.46.80.0/21",
@@ -28861,6 +28993,12 @@
       "region": "sa-east-1",
       "service": "AMAZON",
       "network_border_group": "sa-east-1"
+    },
+    {
+      "ip_prefix": "64.66.145.0/24",
+      "region": "ca-west-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-west-1"
     },
     {
       "ip_prefix": "70.232.120.0/22",
@@ -29217,12 +29355,6 @@
       "network_border_group": "me-south-1"
     },
     {
-      "ip_prefix": "35.98.144.0/20",
-      "region": "ap-southeast-2",
-      "service": "AMAZON",
-      "network_border_group": "ap-southeast-2"
-    },
-    {
       "ip_prefix": "36.103.232.0/25",
       "region": "GLOBAL",
       "service": "AMAZON",
@@ -29565,6 +29697,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "63.249.196.0/24",
+      "region": "il-central-1",
+      "service": "AMAZON",
+      "network_border_group": "il-central-1"
+    },
+    {
       "ip_prefix": "64.252.71.0/24",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -29653,6 +29791,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "35.128.64.0/18",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "52.93.14.0/24",
@@ -29811,12 +29955,6 @@
       "network_border_group": "eu-west-1"
     },
     {
-      "ip_prefix": "35.96.250.0/24",
-      "region": "eu-west-3",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-3"
-    },
-    {
       "ip_prefix": "35.155.0.0/16",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -29919,12 +30057,6 @@
       "network_border_group": "ap-southeast-3"
     },
     {
-      "ip_prefix": "35.111.132.0/22",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
-    },
-    {
       "ip_prefix": "52.76.0.0/17",
       "region": "ap-southeast-1",
       "service": "AMAZON",
@@ -29965,6 +30097,12 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "64.73.192.0/24",
+      "region": "us-gov-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-gov-west-1"
     },
     {
       "ip_prefix": "72.242.0.0/15",
@@ -30915,6 +31053,12 @@
       "network_border_group": "cn-north-1"
     },
     {
+      "ip_prefix": "64.66.129.0/24",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ip_prefix": "65.8.0.0/16",
       "region": "GLOBAL",
       "service": "AMAZON",
@@ -31155,6 +31299,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "3.4.14.16/29",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ip_prefix": "3.4.15.80/29",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -31225,12 +31375,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.96.3.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "52.93.90.194/32",
@@ -31522,9 +31666,9 @@
     },
     {
       "ip_prefix": "64.73.201.0/24",
-      "region": "us-east-1",
+      "region": "eu-west-2",
       "service": "AMAZON",
-      "network_border_group": "us-east-1"
+      "network_border_group": "eu-west-2"
     },
     {
       "ip_prefix": "76.223.170.48/28",
@@ -31687,6 +31831,12 @@
       "region": "ap-southeast-6",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-6"
+    },
+    {
+      "ip_prefix": "3.4.12.78/32",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "3.4.15.104/29",
@@ -32085,18 +32235,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ip_prefix": "35.96.0.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.249.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "46.137.0.0/17",
       "region": "eu-west-1",
       "service": "AMAZON",
@@ -32137,6 +32275,12 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "64.66.135.0/24",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "69.107.11.16/29",
@@ -32245,12 +32389,6 @@
       "region": "me-south-1",
       "service": "AMAZON",
       "network_border_group": "me-south-1-mct-1"
-    },
-    {
-      "ip_prefix": "35.96.9.0/24",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "52.82.192.0/18",
@@ -32439,6 +32577,12 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ip_prefix": "104.255.56.69/32",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ip_prefix": "150.222.42.0/26",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -32497,12 +32641,6 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.42.0/24",
-      "region": "ap-south-1",
-      "service": "AMAZON",
-      "network_border_group": "ap-south-1"
     },
     {
       "ip_prefix": "52.82.188.0/22",
@@ -33489,6 +33627,18 @@
       "network_border_group": "ap-south-1"
     },
     {
+      "ip_prefix": "15.252.46.0/23",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
+    },
+    {
+      "ip_prefix": "15.252.48.0/23",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
+    },
+    {
       "ip_prefix": "3.110.57.0/24",
       "region": "ap-south-1",
       "service": "AMAZON",
@@ -33523,6 +33673,12 @@
       "region": "ap-south-1",
       "service": "AMAZON",
       "network_border_group": "ap-south-1"
+    },
+    {
+      "ip_prefix": "16.113.58.0/23",
+      "region": "ap-south-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-2"
     },
     {
       "ip_prefix": "18.60.125.0/24",
@@ -34341,6 +34497,12 @@
       "network_border_group": "eu-central-1"
     },
     {
+      "ip_prefix": "63.186.244.0/23",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ip_prefix": "16.62.140.0/25",
       "region": "eu-central-2",
       "service": "AMAZON",
@@ -34462,6 +34624,12 @@
     },
     {
       "ip_prefix": "16.171.80.0/22",
+      "region": "eu-north-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-north-1"
+    },
+    {
+      "ip_prefix": "16.192.132.0/23",
       "region": "eu-north-1",
       "service": "AMAZON",
       "network_border_group": "eu-north-1"
@@ -34870,6 +35038,12 @@
     },
     {
       "ip_prefix": "3.8.168.0/23",
+      "region": "eu-west-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-2"
+    },
+    {
+      "ip_prefix": "51.24.128.0/23",
       "region": "eu-west-2",
       "service": "AMAZON",
       "network_border_group": "eu-west-2"
@@ -35662,6 +35836,12 @@
     },
     {
       "ip_prefix": "18.226.2.0/23",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
+    },
+    {
+      "ip_prefix": "18.227.204.0/23",
       "region": "us-east-2",
       "service": "AMAZON",
       "network_border_group": "us-east-2"
@@ -39105,6 +39285,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ip_prefix": "35.50.240.0/24",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ip_prefix": "35.50.139.0/24",
       "region": "us-east-1",
       "service": "IVS_REALTIME",
@@ -39193,6 +39379,12 @@
       "region": "ap-northeast-1",
       "service": "IVS_REALTIME",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "35.50.242.0/24",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ip_prefix": "35.50.210.0/24",
@@ -39447,6 +39639,12 @@
       "network_border_group": "eu-west-3"
     },
     {
+      "ip_prefix": "35.50.241.0/24",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ip_prefix": "35.55.41.0/24",
       "region": "eu-north-1",
       "service": "IVS_REALTIME",
@@ -39520,6 +39718,12 @@
     },
     {
       "ip_prefix": "35.55.37.0/24",
+      "region": "us-west-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "35.50.145.0/24",
       "region": "us-west-2",
       "service": "IVS_REALTIME",
       "network_border_group": "us-west-2"
@@ -40077,12 +40281,6 @@
       "network_border_group": "ap-northeast-2"
     },
     {
-      "ip_prefix": "35.111.254.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "51.168.0.0/15",
       "region": "me-west-1",
       "service": "EC2",
@@ -40155,6 +40353,18 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "63.249.164.0/24",
+      "region": "ap-south-2",
+      "service": "EC2",
+      "network_border_group": "ap-south-2"
+    },
+    {
+      "ip_prefix": "64.66.157.0/24",
+      "region": "ap-southeast-5",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
       "ip_prefix": "96.0.80.0/22",
       "region": "ap-southeast-2",
       "service": "EC2",
@@ -40201,12 +40411,6 @@
       "region": "eu-central-1",
       "service": "EC2",
       "network_border_group": "eu-central-1"
-    },
-    {
-      "ip_prefix": "35.96.248.0/24",
-      "region": "eu-west-2",
-      "service": "EC2",
-      "network_border_group": "eu-west-2"
     },
     {
       "ip_prefix": "50.16.0.0/15",
@@ -40311,6 +40515,12 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ip_prefix": "63.249.129.0/24",
+      "region": "ap-southeast-6",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-6"
+    },
+    {
       "ip_prefix": "63.249.169.0/24",
       "region": "ap-northeast-2",
       "service": "EC2",
@@ -40353,18 +40563,6 @@
       "network_border_group": "ca-west-1"
     },
     {
-      "ip_prefix": "35.96.28.0/23",
-      "region": "us-east-1",
-      "service": "EC2",
-      "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.96.240.0/24",
-      "region": "ap-southeast-2",
-      "service": "EC2",
-      "network_border_group": "ap-southeast-2"
-    },
-    {
       "ip_prefix": "43.206.0.0/15",
       "region": "ap-northeast-1",
       "service": "EC2",
@@ -40381,6 +40579,12 @@
       "region": "ap-east-1",
       "service": "EC2",
       "network_border_group": "ap-east-1"
+    },
+    {
+      "ip_prefix": "63.249.130.0/24",
+      "region": "ap-southeast-6",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-6"
     },
     {
       "ip_prefix": "64.73.207.0/24",
@@ -40453,6 +40657,12 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "63.249.165.0/24",
+      "region": "ap-south-2",
+      "service": "EC2",
+      "network_border_group": "ap-south-2"
     },
     {
       "ip_prefix": "99.77.55.49/32",
@@ -40563,6 +40773,12 @@
       "network_border_group": "ap-northeast-2"
     },
     {
+      "ip_prefix": "63.249.173.0/24",
+      "region": "ap-southeast-5",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
       "ip_prefix": "99.77.132.0/24",
       "region": "us-west-1",
       "service": "EC2",
@@ -40659,6 +40875,18 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "63.249.161.0/24",
+      "region": "ap-east-1",
+      "service": "EC2",
+      "network_border_group": "ap-east-1"
+    },
+    {
+      "ip_prefix": "63.249.212.0/24",
+      "region": "cn-northwest-1",
+      "service": "EC2",
+      "network_border_group": "cn-northwest-1"
+    },
+    {
       "ip_prefix": "15.220.207.0/24",
       "region": "us-west-2",
       "service": "EC2",
@@ -40735,6 +40963,12 @@
       "region": "eu-west-1",
       "service": "EC2",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "63.249.213.0/24",
+      "region": "eu-central-2",
+      "service": "EC2",
+      "network_border_group": "eu-central-2"
     },
     {
       "ip_prefix": "99.77.55.46/32",
@@ -40935,12 +41169,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ip_prefix": "35.111.252.0/24",
-      "region": "us-gov-west-1",
-      "service": "EC2",
-      "network_border_group": "us-gov-west-1"
-    },
-    {
       "ip_prefix": "52.94.250.192/28",
       "region": "us-south-1",
       "service": "EC2",
@@ -41017,6 +41245,12 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "63.249.184.0/24",
+      "region": "eu-south-1",
+      "service": "EC2",
+      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "64.252.89.0/24",
@@ -41139,12 +41373,6 @@
       "network_border_group": "ap-south-2"
     },
     {
-      "ip_prefix": "35.96.11.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "52.95.255.16/28",
       "region": "ap-southeast-2",
       "service": "EC2",
@@ -41259,12 +41487,6 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ip_prefix": "35.96.60.0/23",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "54.200.0.0/15",
       "region": "us-west-2",
       "service": "EC2",
@@ -41313,6 +41535,24 @@
       "network_border_group": "ca-west-1"
     },
     {
+      "ip_prefix": "63.249.128.0/24",
+      "region": "ap-southeast-6",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-6"
+    },
+    {
+      "ip_prefix": "64.66.140.0/24",
+      "region": "ap-northeast-1",
+      "service": "EC2",
+      "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "64.73.199.0/24",
+      "region": "us-gov-east-1",
+      "service": "EC2",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
       "ip_prefix": "99.77.238.0/24",
       "region": "ap-south-1",
       "service": "EC2",
@@ -41355,6 +41595,12 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "63.249.147.0/24",
+      "region": "af-south-1",
+      "service": "EC2",
+      "network_border_group": "af-south-1"
+    },
+    {
       "ip_prefix": "63.249.158.0/24",
       "region": "sa-east-1",
       "service": "EC2",
@@ -41379,6 +41625,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ip_prefix": "35.50.240.0/24",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ip_prefix": "35.71.94.0/24",
       "region": "eusc-de-east-1",
       "service": "EC2",
@@ -41391,10 +41643,10 @@
       "network_border_group": "ap-southeast-1"
     },
     {
-      "ip_prefix": "35.96.26.0/23",
-      "region": "us-east-2",
+      "ip_prefix": "64.66.162.0/24",
+      "region": "ap-northeast-2",
       "service": "EC2",
-      "network_border_group": "us-east-2"
+      "network_border_group": "ap-northeast-2"
     },
     {
       "ip_prefix": "64.252.72.0/24",
@@ -41553,12 +41805,6 @@
       "network_border_group": "eu-south-1"
     },
     {
-      "ip_prefix": "35.96.252.0/24",
-      "region": "ca-central-1",
-      "service": "EC2",
-      "network_border_group": "ca-central-1"
-    },
-    {
       "ip_prefix": "69.235.128.0/18",
       "region": "cn-northwest-1",
       "service": "EC2",
@@ -41599,6 +41845,12 @@
       "region": "ap-southeast-1",
       "service": "EC2",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ip_prefix": "63.249.180.0/24",
+      "region": "ap-southeast-4",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ip_prefix": "204.236.128.0/18",
@@ -41677,6 +41929,12 @@
       "region": "eu-west-1",
       "service": "EC2",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "63.249.160.0/24",
+      "region": "ap-east-1",
+      "service": "EC2",
+      "network_border_group": "ap-east-1"
     },
     {
       "ip_prefix": "64.252.76.0/24",
@@ -41767,6 +42025,12 @@
       "region": "eu-west-1",
       "service": "EC2",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "63.249.206.0/24",
+      "region": "ca-west-1",
+      "service": "EC2",
+      "network_border_group": "ca-west-1"
     },
     {
       "ip_prefix": "64.187.128.0/20",
@@ -41883,6 +42147,18 @@
       "network_border_group": "us-gov-west-1"
     },
     {
+      "ip_prefix": "64.66.147.0/24",
+      "region": "eu-south-2",
+      "service": "EC2",
+      "network_border_group": "eu-south-2"
+    },
+    {
+      "ip_prefix": "64.73.200.0/24",
+      "region": "us-gov-east-1",
+      "service": "EC2",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
       "ip_prefix": "64.73.213.0/24",
       "region": "us-west-2",
       "service": "EC2",
@@ -41919,6 +42195,12 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "64.66.150.0/24",
+      "region": "ap-southeast-7",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-7"
+    },
+    {
       "ip_prefix": "122.200.61.0/24",
       "region": "ap-southeast-2",
       "service": "EC2",
@@ -41935,6 +42217,12 @@
       "region": "eu-west-3",
       "service": "EC2",
       "network_border_group": "eu-west-3"
+    },
+    {
+      "ip_prefix": "64.66.136.0/24",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "157.241.0.0/16",
@@ -42009,6 +42297,12 @@
       "network_border_group": "eu-central-1-wl1-muc-wlz-1"
     },
     {
+      "ip_prefix": "15.241.0.0/16",
+      "region": "af-south-1",
+      "service": "EC2",
+      "network_border_group": "af-south-1"
+    },
+    {
       "ip_prefix": "18.34.72.0/21",
       "region": "us-east-2",
       "service": "EC2",
@@ -42019,12 +42313,6 @@
       "region": "ap-south-1",
       "service": "EC2",
       "network_border_group": "ap-south-1"
-    },
-    {
-      "ip_prefix": "35.97.16.0/20",
-      "region": "GLOBAL",
-      "service": "EC2",
-      "network_border_group": "GLOBAL"
     },
     {
       "ip_prefix": "35.176.0.0/15",
@@ -42061,12 +42349,6 @@
       "region": "ap-southeast-2",
       "service": "EC2",
       "network_border_group": "ap-southeast-2"
-    },
-    {
-      "ip_prefix": "35.111.136.0/22",
-      "region": "us-east-2",
-      "service": "EC2",
-      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "51.20.0.0/16",
@@ -42219,18 +42501,6 @@
       "network_border_group": "ap-southeast-1"
     },
     {
-      "ip_prefix": "35.96.1.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.41.0/24",
-      "region": "eu-central-2",
-      "service": "EC2",
-      "network_border_group": "eu-central-2"
-    },
-    {
       "ip_prefix": "64.252.68.0/24",
       "region": "us-east-1",
       "service": "EC2",
@@ -42351,6 +42621,12 @@
       "network_border_group": "ap-northeast-2"
     },
     {
+      "ip_prefix": "63.249.162.0/24",
+      "region": "ap-east-1",
+      "service": "EC2",
+      "network_border_group": "ap-east-1"
+    },
+    {
       "ip_prefix": "64.252.102.0/24",
       "region": "ap-southeast-1",
       "service": "EC2",
@@ -42423,12 +42699,6 @@
       "network_border_group": "il-central-1"
     },
     {
-      "ip_prefix": "35.96.47.0/24",
-      "region": "eu-central-1",
-      "service": "EC2",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ip_prefix": "63.249.155.0/24",
       "region": "eu-central-1",
       "service": "EC2",
@@ -42469,6 +42739,12 @@
       "region": "us-east-2",
       "service": "EC2",
       "network_border_group": "us-east-2"
+    },
+    {
+      "ip_prefix": "23.254.26.0/23",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "51.45.0.0/16",
@@ -42601,18 +42877,6 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.7.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.34.0/24",
-      "region": "eu-west-1",
-      "service": "EC2",
-      "network_border_group": "eu-west-1"
     },
     {
       "ip_prefix": "99.77.55.32/32",
@@ -42855,6 +43119,12 @@
       "network_border_group": "us-west-1"
     },
     {
+      "ip_prefix": "64.66.155.0/24",
+      "region": "mx-central-1",
+      "service": "EC2",
+      "network_border_group": "mx-central-1"
+    },
+    {
       "ip_prefix": "208.78.135.0/24",
       "region": "eu-west-2",
       "service": "EC2",
@@ -42873,6 +43143,12 @@
       "network_border_group": "ap-south-2"
     },
     {
+      "ip_prefix": "35.71.92.0/24",
+      "region": "me-west-1",
+      "service": "EC2",
+      "network_border_group": "me-west-1"
+    },
+    {
       "ip_prefix": "52.57.0.0/16",
       "region": "eu-central-1",
       "service": "EC2",
@@ -42883,6 +43159,12 @@
       "region": "ap-southeast-3",
       "service": "EC2",
       "network_border_group": "ap-southeast-3"
+    },
+    {
+      "ip_prefix": "63.249.195.0/24",
+      "region": "il-central-1",
+      "service": "EC2",
+      "network_border_group": "il-central-1"
     },
     {
       "ip_prefix": "99.151.80.0/21",
@@ -42901,12 +43183,6 @@
       "region": "ca-west-1",
       "service": "EC2",
       "network_border_group": "ca-west-1"
-    },
-    {
-      "ip_prefix": "35.96.254.0/24",
-      "region": "us-east-2",
-      "service": "EC2",
-      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "54.112.0.0/18",
@@ -42961,12 +43237,6 @@
       "region": "ap-southeast-1",
       "service": "EC2",
       "network_border_group": "ap-southeast-1"
-    },
-    {
-      "ip_prefix": "35.96.12.0/24",
-      "region": "eu-central-1",
-      "service": "EC2",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "63.249.151.0/24",
@@ -43029,6 +43299,12 @@
       "network_border_group": "ca-west-1"
     },
     {
+      "ip_prefix": "64.66.160.0/24",
+      "region": "eu-west-2",
+      "service": "EC2",
+      "network_border_group": "eu-west-2"
+    },
+    {
       "ip_prefix": "192.43.184.0/24",
       "region": "us-east-2",
       "service": "EC2",
@@ -43039,18 +43315,6 @@
       "region": "eu-north-1",
       "service": "EC2",
       "network_border_group": "eu-north-1"
-    },
-    {
-      "ip_prefix": "35.96.128.0/20",
-      "region": "ap-southeast-2",
-      "service": "EC2",
-      "network_border_group": "ap-southeast-2"
-    },
-    {
-      "ip_prefix": "35.111.128.0/22",
-      "region": "us-east-2",
-      "service": "EC2",
-      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "52.44.0.0/15",
@@ -43179,12 +43443,6 @@
       "network_border_group": "us-east-1-msp-1"
     },
     {
-      "ip_prefix": "35.96.46.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "51.0.128.0/21",
       "region": "eusc-de-east-1",
       "service": "EC2",
@@ -43201,6 +43459,12 @@
       "region": "us-west-1",
       "service": "EC2",
       "network_border_group": "us-west-1"
+    },
+    {
+      "ip_prefix": "64.66.134.0/24",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "64.73.202.0/24",
@@ -43227,10 +43491,22 @@
       "network_border_group": "ap-southeast-2"
     },
     {
-      "ip_prefix": "35.96.39.0/24",
+      "ip_prefix": "35.50.242.0/24",
       "region": "ap-southeast-2",
       "service": "EC2",
       "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ip_prefix": "63.249.211.0/24",
+      "region": "cn-northwest-1",
+      "service": "EC2",
+      "network_border_group": "cn-northwest-1"
+    },
+    {
+      "ip_prefix": "64.66.149.0/24",
+      "region": "ca-central-1",
+      "service": "EC2",
+      "network_border_group": "ca-central-1"
     },
     {
       "ip_prefix": "96.0.131.0/24",
@@ -43305,12 +43581,6 @@
       "network_border_group": "us-west-1"
     },
     {
-      "ip_prefix": "35.96.96.0/20",
-      "region": "eu-central-1",
-      "service": "EC2",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ip_prefix": "52.90.0.0/15",
       "region": "us-east-1",
       "service": "EC2",
@@ -43327,6 +43597,12 @@
       "region": "ap-northeast-3",
       "service": "EC2",
       "network_border_group": "ap-northeast-3"
+    },
+    {
+      "ip_prefix": "63.249.183.0/24",
+      "region": "eu-south-1",
+      "service": "EC2",
+      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "63.249.194.0/24",
@@ -43485,6 +43761,12 @@
       "network_border_group": "us-west-2-lax-1"
     },
     {
+      "ip_prefix": "64.73.198.0/24",
+      "region": "us-gov-east-1",
+      "service": "EC2",
+      "network_border_group": "us-gov-east-1"
+    },
+    {
       "ip_prefix": "83.119.128.0/18",
       "region": "eu-central-1",
       "service": "EC2",
@@ -43585,6 +43867,12 @@
       "region": "eu-west-2",
       "service": "EC2",
       "network_border_group": "eu-west-2"
+    },
+    {
+      "ip_prefix": "136.18.164.0/23",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "13.214.0.0/15",
@@ -43707,6 +43995,12 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ip_prefix": "64.66.151.0/24",
+      "region": "af-south-1",
+      "service": "EC2",
+      "network_border_group": "af-south-1"
+    },
+    {
       "ip_prefix": "176.34.0.0/19",
       "region": "ap-northeast-1",
       "service": "EC2",
@@ -43791,6 +44085,12 @@
       "network_border_group": "cn-north-1"
     },
     {
+      "ip_prefix": "63.249.208.0/24",
+      "region": "eu-south-2",
+      "service": "EC2",
+      "network_border_group": "eu-south-2"
+    },
+    {
       "ip_prefix": "99.77.129.0/24",
       "region": "us-east-1",
       "service": "EC2",
@@ -43821,12 +44121,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ip_prefix": "35.96.45.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "43.204.0.0/15",
       "region": "ap-south-1",
       "service": "EC2",
@@ -43843,6 +44137,12 @@
       "region": "ap-southeast-1",
       "service": "EC2",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ip_prefix": "64.66.159.0/24",
+      "region": "sa-east-1",
+      "service": "EC2",
+      "network_border_group": "sa-east-1"
     },
     {
       "ip_prefix": "99.77.55.254/32",
@@ -43867,6 +44167,12 @@
       "region": "eu-west-1",
       "service": "EC2",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "64.66.154.0/24",
+      "region": "eu-west-3",
+      "service": "EC2",
+      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "142.4.179.0/24",
@@ -43927,12 +44233,6 @@
       "region": "eu-north-1",
       "service": "EC2",
       "network_border_group": "eu-north-1"
-    },
-    {
-      "ip_prefix": "35.96.43.0/24",
-      "region": "sa-east-1",
-      "service": "EC2",
-      "network_border_group": "sa-east-1"
     },
     {
       "ip_prefix": "63.249.167.0/24",
@@ -44145,10 +44445,22 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ip_prefix": "63.249.149.0/24",
+      "region": "af-south-1",
+      "service": "EC2",
+      "network_border_group": "af-south-1"
+    },
+    {
       "ip_prefix": "63.249.207.0/24",
       "region": "eu-south-2",
       "service": "EC2",
       "network_border_group": "eu-south-2"
+    },
+    {
+      "ip_prefix": "63.249.210.0/24",
+      "region": "cn-northwest-1",
+      "service": "EC2",
+      "network_border_group": "cn-northwest-1"
     },
     {
       "ip_prefix": "18.142.0.0/15",
@@ -44397,12 +44709,6 @@
       "network_border_group": "ap-southeast-2"
     },
     {
-      "ip_prefix": "35.96.22.0/23",
-      "region": "ca-central-1",
-      "service": "EC2",
-      "network_border_group": "ca-central-1"
-    },
-    {
       "ip_prefix": "64.252.78.0/24",
       "region": "sa-east-1",
       "service": "EC2",
@@ -44523,12 +44829,6 @@
       "network_border_group": "ap-east-2"
     },
     {
-      "ip_prefix": "35.96.4.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "139.56.26.0/23",
       "region": "us-east-1",
       "service": "EC2",
@@ -44613,12 +44913,6 @@
       "network_border_group": "eu-west-2"
     },
     {
-      "ip_prefix": "35.96.253.0/24",
-      "region": "us-east-1",
-      "service": "EC2",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ip_prefix": "51.96.0.0/16",
       "region": "eu-central-2",
       "service": "EC2",
@@ -44653,18 +44947,6 @@
       "region": "sa-west-1",
       "service": "EC2",
       "network_border_group": "sa-west-1"
-    },
-    {
-      "ip_prefix": "35.96.6.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.35.0/24",
-      "region": "eu-west-3",
-      "service": "EC2",
-      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "50.19.0.0/16",
@@ -44757,12 +45039,6 @@
       "network_border_group": "us-west-1"
     },
     {
-      "ip_prefix": "35.111.255.0/24",
-      "region": "us-east-1",
-      "service": "EC2",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ip_prefix": "52.94.250.80/28",
       "region": "ap-southeast-5",
       "service": "EC2",
@@ -44827,6 +45103,12 @@
       "region": "af-south-1",
       "service": "EC2",
       "network_border_group": "af-south-1"
+    },
+    {
+      "ip_prefix": "64.66.156.0/24",
+      "region": "ap-east-1",
+      "service": "EC2",
+      "network_border_group": "ap-east-1"
     },
     {
       "ip_prefix": "64.252.73.0/24",
@@ -44919,12 +45201,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "35.96.80.0/20",
-      "region": "eu-west-2",
-      "service": "EC2",
-      "network_border_group": "eu-west-2"
-    },
-    {
       "ip_prefix": "43.194.0.0/20",
       "region": "cn-northwest-1",
       "service": "EC2",
@@ -44935,6 +45211,18 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "63.249.174.0/24",
+      "region": "ap-southeast-5",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
+      "ip_prefix": "64.66.138.0/24",
+      "region": "eu-west-1",
+      "service": "EC2",
+      "network_border_group": "eu-west-1"
     },
     {
       "ip_prefix": "96.0.12.0/22",
@@ -44967,16 +45255,22 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ip_prefix": "35.96.38.0/24",
-      "region": "ap-northeast-1",
-      "service": "EC2",
-      "network_border_group": "ap-northeast-1"
-    },
-    {
       "ip_prefix": "52.95.245.0/24",
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "63.249.189.0/24",
+      "region": "mx-central-1",
+      "service": "EC2",
+      "network_border_group": "mx-central-1"
+    },
+    {
+      "ip_prefix": "63.249.197.0/24",
+      "region": "il-central-1",
+      "service": "EC2",
+      "network_border_group": "il-central-1"
     },
     {
       "ip_prefix": "99.77.142.0/24",
@@ -44995,12 +45289,6 @@
       "region": "ap-south-1",
       "service": "EC2",
       "network_border_group": "ap-south-1"
-    },
-    {
-      "ip_prefix": "35.96.48.0/21",
-      "region": "eu-central-1",
-      "service": "EC2",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "46.51.216.0/21",
@@ -45049,18 +45337,6 @@
       "region": "ap-southeast-7",
       "service": "EC2",
       "network_border_group": "ap-southeast-7"
-    },
-    {
-      "ip_prefix": "35.96.8.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.246.0/24",
-      "region": "us-east-2",
-      "service": "EC2",
-      "network_border_group": "us-east-2"
     },
     {
       "ip_prefix": "52.94.248.32/28",
@@ -45187,12 +45463,6 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
-    },
-    {
-      "ip_prefix": "35.96.36.0/24",
-      "region": "eu-south-1",
-      "service": "EC2",
-      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "46.51.128.0/18",
@@ -45435,6 +45705,12 @@
       "network_border_group": "eu-north-1"
     },
     {
+      "ip_prefix": "64.66.130.0/24",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ip_prefix": "40.192.0.0/17",
       "region": "ap-south-2",
       "service": "EC2",
@@ -45573,18 +45849,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ip_prefix": "35.96.32.0/24",
-      "region": "us-east-1",
-      "service": "EC2",
-      "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.97.0.0/20",
-      "region": "GLOBAL",
-      "service": "EC2",
-      "network_border_group": "GLOBAL"
-    },
-    {
       "ip_prefix": "63.249.177.0/24",
       "region": "eu-west-2",
       "service": "EC2",
@@ -45613,6 +45877,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "63.249.190.0/24",
+      "region": "mx-central-1",
+      "service": "EC2",
+      "network_border_group": "mx-central-1"
     },
     {
       "ip_prefix": "99.77.184.0/24",
@@ -45649,6 +45919,12 @@
       "region": "ap-southeast-1",
       "service": "EC2",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ip_prefix": "35.128.128.0/18",
+      "region": "us-south-1",
+      "service": "EC2",
+      "network_border_group": "us-south-1"
     },
     {
       "ip_prefix": "63.249.176.0/24",
@@ -45727,6 +46003,12 @@
       "region": "eu-west-1",
       "service": "EC2",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "64.66.152.0/24",
+      "region": "ap-south-1",
+      "service": "EC2",
+      "network_border_group": "ap-south-1"
     },
     {
       "ip_prefix": "64.73.211.0/24",
@@ -45945,10 +46227,22 @@
       "network_border_group": "eu-south-1"
     },
     {
+      "ip_prefix": "54.115.0.0/16",
+      "region": "GLOBAL",
+      "service": "EC2",
+      "network_border_group": "GLOBAL"
+    },
+    {
       "ip_prefix": "54.215.0.0/16",
       "region": "us-west-1",
       "service": "EC2",
       "network_border_group": "us-west-1"
+    },
+    {
+      "ip_prefix": "64.66.158.0/24",
+      "region": "eu-south-1",
+      "service": "EC2",
+      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "161.188.0.0/20",
@@ -45967,18 +46261,6 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
-    },
-    {
-      "ip_prefix": "35.96.24.0/23",
-      "region": "eu-west-2",
-      "service": "EC2",
-      "network_border_group": "eu-west-2"
-    },
-    {
-      "ip_prefix": "35.96.242.0/24",
-      "region": "eu-central-1",
-      "service": "EC2",
-      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "43.218.0.0/16",
@@ -46101,6 +46383,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "40.235.128.0/18",
+      "region": "us-south-1",
+      "service": "EC2",
+      "network_border_group": "us-south-1"
+    },
+    {
       "ip_prefix": "52.70.0.0/15",
       "region": "us-east-1",
       "service": "EC2",
@@ -46141,6 +46429,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2-den-1"
+    },
+    {
+      "ip_prefix": "64.66.161.0/24",
+      "region": "ap-south-2",
+      "service": "EC2",
+      "network_border_group": "ap-south-2"
     },
     {
       "ip_prefix": "64.73.210.0/24",
@@ -46317,6 +46611,12 @@
       "network_border_group": "ap-east-1"
     },
     {
+      "ip_prefix": "63.249.136.0/24",
+      "region": "cn-north-1",
+      "service": "EC2",
+      "network_border_group": "cn-north-1"
+    },
+    {
       "ip_prefix": "99.151.96.0/21",
       "region": "us-gov-east-1",
       "service": "EC2",
@@ -46387,6 +46687,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "63.249.199.0/24",
+      "region": "ap-east-2",
+      "service": "EC2",
+      "network_border_group": "ap-east-2"
     },
     {
       "ip_prefix": "64.252.83.0/24",
@@ -46497,10 +46803,16 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "64.73.193.0/24",
-      "region": "us-east-1",
+      "ip_prefix": "64.66.144.0/24",
+      "region": "eu-central-2",
       "service": "EC2",
-      "network_border_group": "us-east-1"
+      "network_border_group": "eu-central-2"
+    },
+    {
+      "ip_prefix": "64.73.193.0/24",
+      "region": "us-gov-west-1",
+      "service": "EC2",
+      "network_border_group": "us-gov-west-1"
     },
     {
       "ip_prefix": "216.198.200.0/21",
@@ -46537,6 +46849,12 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "64.66.131.0/24",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "64.252.100.0/24",
@@ -46641,12 +46959,6 @@
       "network_border_group": "eu-north-1"
     },
     {
-      "ip_prefix": "35.96.58.0/23",
-      "region": "eu-central-1",
-      "service": "EC2",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ip_prefix": "50.18.0.0/16",
       "region": "us-west-1",
       "service": "EC2",
@@ -46663,6 +46975,12 @@
       "region": "eu-west-3",
       "service": "EC2",
       "network_border_group": "eu-west-3"
+    },
+    {
+      "ip_prefix": "63.249.179.0/24",
+      "region": "ap-southeast-4",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ip_prefix": "96.0.72.0/21",
@@ -46785,6 +47103,12 @@
       "network_border_group": "ap-southeast-5"
     },
     {
+      "ip_prefix": "63.249.205.0/24",
+      "region": "ca-west-1",
+      "service": "EC2",
+      "network_border_group": "ca-west-1"
+    },
+    {
       "ip_prefix": "89.60.0.0/15",
       "region": "eu-south-2",
       "service": "EC2",
@@ -46815,18 +47139,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ip_prefix": "35.96.112.0/20",
-      "region": "eu-south-1",
-      "service": "EC2",
-      "network_border_group": "eu-south-1"
-    },
-    {
-      "ip_prefix": "35.96.251.0/24",
-      "region": "ca-west-1",
-      "service": "EC2",
-      "network_border_group": "ca-west-1"
-    },
-    {
       "ip_prefix": "35.178.0.0/15",
       "region": "eu-west-2",
       "service": "EC2",
@@ -46852,6 +47164,12 @@
     },
     {
       "ip_prefix": "52.94.116.0/22",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "64.66.128.0/24",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -46903,6 +47221,12 @@
       "region": "eu-central-1",
       "service": "EC2",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ip_prefix": "64.66.142.0/24",
+      "region": "ap-southeast-4",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ip_prefix": "64.73.216.0/24",
@@ -46989,6 +47313,12 @@
       "network_border_group": "eu-north-1"
     },
     {
+      "ip_prefix": "64.66.133.0/24",
+      "region": "ap-northeast-3",
+      "service": "EC2",
+      "network_border_group": "ap-northeast-3"
+    },
+    {
       "ip_prefix": "64.252.104.0/24",
       "region": "ap-southeast-1",
       "service": "EC2",
@@ -47005,6 +47335,12 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "5.60.48.0/20",
+      "region": "us-south-1",
+      "service": "EC2",
+      "network_border_group": "us-south-1"
     },
     {
       "ip_prefix": "13.54.0.0/15",
@@ -47047,12 +47383,6 @@
       "region": "us-gov-east-1",
       "service": "EC2",
       "network_border_group": "us-gov-east-1"
-    },
-    {
-      "ip_prefix": "35.96.40.0/24",
-      "region": "af-south-1",
-      "service": "EC2",
-      "network_border_group": "af-south-1"
     },
     {
       "ip_prefix": "52.95.235.0/24",
@@ -47121,12 +47451,6 @@
       "network_border_group": "eu-west-2"
     },
     {
-      "ip_prefix": "35.96.44.0/24",
-      "region": "ca-west-1",
-      "service": "EC2",
-      "network_border_group": "ca-west-1"
-    },
-    {
       "ip_prefix": "52.94.248.144/28",
       "region": "ap-south-1",
       "service": "EC2",
@@ -47143,6 +47467,12 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "64.66.148.0/24",
+      "region": "il-central-1",
+      "service": "EC2",
+      "network_border_group": "il-central-1"
     },
     {
       "ip_prefix": "99.150.72.0/21",
@@ -47307,6 +47637,12 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ip_prefix": "64.66.137.0/24",
+      "region": "us-west-1",
+      "service": "EC2",
+      "network_border_group": "us-west-1"
+    },
+    {
       "ip_prefix": "99.77.55.1/32",
       "region": "eu-south-2",
       "service": "EC2",
@@ -47359,6 +47695,12 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ip_prefix": "63.249.137.0/24",
+      "region": "cn-north-1",
+      "service": "EC2",
+      "network_border_group": "cn-north-1"
     },
     {
       "ip_prefix": "99.150.16.0/21",
@@ -47415,6 +47757,12 @@
       "network_border_group": "us-west-1"
     },
     {
+      "ip_prefix": "63.249.163.0/24",
+      "region": "ap-south-2",
+      "service": "EC2",
+      "network_border_group": "ap-south-2"
+    },
+    {
       "ip_prefix": "99.77.141.0/24",
       "region": "ap-northeast-2",
       "service": "EC2",
@@ -47431,6 +47779,18 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "64.66.153.0/24",
+      "region": "ap-southeast-3",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-3"
+    },
+    {
+      "ip_prefix": "64.73.194.0/24",
+      "region": "us-gov-west-1",
+      "service": "EC2",
+      "network_border_group": "us-gov-west-1"
     },
     {
       "ip_prefix": "216.198.231.0/24",
@@ -47601,6 +47961,12 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ip_prefix": "23.254.28.0/23",
+      "region": "us-south-1",
+      "service": "EC2",
+      "network_border_group": "us-south-1"
+    },
+    {
       "ip_prefix": "52.94.248.112/28",
       "region": "eu-central-1",
       "service": "EC2",
@@ -47661,6 +48027,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ip_prefix": "35.50.241.0/24",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ip_prefix": "35.55.41.0/24",
       "region": "eu-north-1",
       "service": "EC2",
@@ -47695,12 +48067,6 @@
       "region": "ap-southeast-2",
       "service": "EC2",
       "network_border_group": "ap-southeast-2"
-    },
-    {
-      "ip_prefix": "35.96.16.0/23",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "35.168.0.0/13",
@@ -47823,12 +48189,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "35.96.33.0/24",
-      "region": "us-west-1",
-      "service": "EC2",
-      "network_border_group": "us-west-1"
-    },
-    {
       "ip_prefix": "56.155.0.0/17",
       "region": "ap-northeast-3",
       "service": "EC2",
@@ -47839,6 +48199,12 @@
       "region": "eu-north-1",
       "service": "EC2",
       "network_border_group": "eu-north-1"
+    },
+    {
+      "ip_prefix": "63.249.143.0/24",
+      "region": "ap-southeast-3",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-3"
     },
     {
       "ip_prefix": "99.150.112.0/21",
@@ -47896,9 +48262,9 @@
     },
     {
       "ip_prefix": "1.178.86.0/24",
-      "region": "us-east-2",
+      "region": "ap-southeast-3",
       "service": "EC2",
-      "network_border_group": "us-east-2"
+      "network_border_group": "ap-southeast-3"
     },
     {
       "ip_prefix": "15.129.80.0/22",
@@ -47911,12 +48277,6 @@
       "region": "ap-south-1",
       "service": "EC2",
       "network_border_group": "ap-south-1"
-    },
-    {
-      "ip_prefix": "35.96.5.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "45.57.128.0/18",
@@ -47941,12 +48301,6 @@
       "region": "ca-central-1",
       "service": "EC2",
       "network_border_group": "ca-central-1"
-    },
-    {
-      "ip_prefix": "35.96.244.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "54.66.0.0/16",
@@ -48055,6 +48409,12 @@
       "region": "ap-east-2",
       "service": "EC2",
       "network_border_group": "ap-east-2"
+    },
+    {
+      "ip_prefix": "63.249.191.0/24",
+      "region": "mx-central-1",
+      "service": "EC2",
+      "network_border_group": "mx-central-1"
     },
     {
       "ip_prefix": "3.13.0.0/16",
@@ -48375,6 +48735,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "63.249.141.0/24",
+      "region": "ap-southeast-3",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-3"
+    },
+    {
       "ip_prefix": "99.77.163.0/24",
       "region": "il-central-1",
       "service": "EC2",
@@ -48429,6 +48795,12 @@
       "network_border_group": "eu-south-1"
     },
     {
+      "ip_prefix": "64.66.143.0/24",
+      "region": "ap-southeast-1",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-1"
+    },
+    {
       "ip_prefix": "3.16.0.0/14",
       "region": "us-east-2",
       "service": "EC2",
@@ -48469,6 +48841,12 @@
       "region": "cn-northwest-1",
       "service": "EC2",
       "network_border_group": "cn-northwest-1"
+    },
+    {
+      "ip_prefix": "64.66.141.0/24",
+      "region": "eu-north-1",
+      "service": "EC2",
+      "network_border_group": "eu-north-1"
     },
     {
       "ip_prefix": "99.151.64.0/21",
@@ -48559,12 +48937,6 @@
       "region": "us-east-2",
       "service": "EC2",
       "network_border_group": "us-east-2"
-    },
-    {
-      "ip_prefix": "35.111.253.0/24",
-      "region": "us-gov-east-1",
-      "service": "EC2",
-      "network_border_group": "us-gov-east-1"
     },
     {
       "ip_prefix": "40.164.0.0/16",
@@ -48789,12 +49161,6 @@
       "network_border_group": "us-east-1-mci-1"
     },
     {
-      "ip_prefix": "35.96.2.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "35.154.0.0/16",
       "region": "ap-south-1",
       "service": "EC2",
@@ -48853,6 +49219,12 @@
       "region": "il-central-1",
       "service": "EC2",
       "network_border_group": "il-central-1"
+    },
+    {
+      "ip_prefix": "63.249.209.0/24",
+      "region": "eu-south-2",
+      "service": "EC2",
+      "network_border_group": "eu-south-2"
     },
     {
       "ip_prefix": "96.0.132.0/22",
@@ -48963,18 +49335,6 @@
       "network_border_group": "us-gov-east-1"
     },
     {
-      "ip_prefix": "35.96.10.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.56.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "43.193.65.0/24",
       "region": "cn-northwest-1",
       "service": "EC2",
@@ -49047,12 +49407,6 @@
       "network_border_group": "eu-west-1"
     },
     {
-      "ip_prefix": "35.96.255.0/24",
-      "region": "us-west-1",
-      "service": "EC2",
-      "network_border_group": "us-west-1"
-    },
-    {
       "ip_prefix": "52.94.250.48/28",
       "region": "ca-west-1",
       "service": "EC2",
@@ -49117,6 +49471,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ip_prefix": "63.249.134.0/24",
+      "region": "cn-north-1",
+      "service": "EC2",
+      "network_border_group": "cn-north-1"
     },
     {
       "ip_prefix": "70.232.86.124/32",
@@ -49197,12 +49557,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ip_prefix": "35.96.241.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "43.196.0.0/16",
       "region": "cn-north-1",
       "service": "EC2",
@@ -49237,18 +49591,6 @@
       "region": "eu-central-1",
       "service": "EC2",
       "network_border_group": "eu-central-1"
-    },
-    {
-      "ip_prefix": "35.96.37.0/24",
-      "region": "eu-south-2",
-      "service": "EC2",
-      "network_border_group": "eu-south-2"
-    },
-    {
-      "ip_prefix": "35.96.243.0/24",
-      "region": "eu-west-1",
-      "service": "EC2",
-      "network_border_group": "eu-west-1"
     },
     {
       "ip_prefix": "52.94.249.160/28",
@@ -49341,12 +49683,6 @@
       "network_border_group": "eu-central-1"
     },
     {
-      "ip_prefix": "35.96.144.0/20",
-      "region": "us-east-1",
-      "service": "EC2",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ip_prefix": "54.76.0.0/15",
       "region": "eu-west-1",
       "service": "EC2",
@@ -49437,6 +49773,12 @@
       "network_border_group": "eu-west-3"
     },
     {
+      "ip_prefix": "63.249.214.0/24",
+      "region": "eu-central-2",
+      "service": "EC2",
+      "network_border_group": "eu-central-2"
+    },
+    {
       "ip_prefix": "99.150.104.0/21",
       "region": "af-south-1",
       "service": "EC2",
@@ -49447,6 +49789,12 @@
       "region": "ap-northeast-3",
       "service": "EC2",
       "network_border_group": "ap-northeast-3"
+    },
+    {
+      "ip_prefix": "35.50.145.0/24",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "35.71.101.0/24",
@@ -49561,12 +49909,6 @@
       "region": "ap-east-1",
       "service": "EC2",
       "network_border_group": "ap-east-1"
-    },
-    {
-      "ip_prefix": "35.96.15.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "52.94.146.0/24",
@@ -49695,6 +50037,12 @@
       "network_border_group": "eu-central-1"
     },
     {
+      "ip_prefix": "63.249.175.0/24",
+      "region": "ap-southeast-5",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
       "ip_prefix": "63.249.215.0/24",
       "region": "eu-central-2",
       "service": "EC2",
@@ -49731,6 +50079,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "64.66.146.0/24",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ip_prefix": "64.252.77.0/24",
       "region": "us-east-2",
       "service": "EC2",
@@ -49753,6 +50107,12 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "16.66.0.0/16",
+      "region": "us-gov-east-1",
+      "service": "EC2",
+      "network_border_group": "us-gov-east-1"
     },
     {
       "ip_prefix": "18.89.0.0/18",
@@ -49797,28 +50157,10 @@
       "network_border_group": "sa-east-1"
     },
     {
-      "ip_prefix": "35.96.14.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "31.220.247.0/24",
       "region": "GLOBAL",
       "service": "EC2",
       "network_border_group": "GLOBAL"
-    },
-    {
-      "ip_prefix": "35.96.64.0/20",
-      "region": "eu-west-3",
-      "service": "EC2",
-      "network_border_group": "eu-west-3"
-    },
-    {
-      "ip_prefix": "35.96.245.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "43.208.0.0/15",
@@ -49827,10 +50169,22 @@
       "network_border_group": "ap-southeast-7"
     },
     {
+      "ip_prefix": "63.249.135.0/24",
+      "region": "cn-north-1",
+      "service": "EC2",
+      "network_border_group": "cn-north-1"
+    },
+    {
       "ip_prefix": "63.249.178.0/24",
       "region": "eu-west-2",
       "service": "EC2",
       "network_border_group": "eu-west-2"
+    },
+    {
+      "ip_prefix": "64.66.139.0/24",
+      "region": "eu-central-1",
+      "service": "EC2",
+      "network_border_group": "eu-central-1"
     },
     {
       "ip_prefix": "1.179.103.0/24",
@@ -49993,6 +50347,12 @@
       "region": "sa-east-1",
       "service": "EC2",
       "network_border_group": "sa-east-1"
+    },
+    {
+      "ip_prefix": "64.66.145.0/24",
+      "region": "ca-west-1",
+      "service": "EC2",
+      "network_border_group": "ca-west-1"
     },
     {
       "ip_prefix": "173.83.204.0/23",
@@ -50247,6 +50607,12 @@
       "network_border_group": "eu-central-2"
     },
     {
+      "ip_prefix": "63.249.196.0/24",
+      "region": "il-central-1",
+      "service": "EC2",
+      "network_border_group": "il-central-1"
+    },
+    {
       "ip_prefix": "64.252.71.0/24",
       "region": "us-west-2",
       "service": "EC2",
@@ -50287,6 +50653,12 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1-mci-1"
+    },
+    {
+      "ip_prefix": "35.128.64.0/18",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "52.95.251.0/24",
@@ -50355,12 +50727,6 @@
       "network_border_group": "eu-west-1"
     },
     {
-      "ip_prefix": "35.96.250.0/24",
-      "region": "eu-west-3",
-      "service": "EC2",
-      "network_border_group": "eu-west-3"
-    },
-    {
       "ip_prefix": "35.155.0.0/16",
       "region": "us-west-2",
       "service": "EC2",
@@ -50415,16 +50781,16 @@
       "network_border_group": "ap-southeast-3"
     },
     {
-      "ip_prefix": "35.111.132.0/22",
-      "region": "us-east-2",
-      "service": "EC2",
-      "network_border_group": "us-east-2"
-    },
-    {
       "ip_prefix": "52.76.0.0/17",
       "region": "ap-southeast-1",
       "service": "EC2",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ip_prefix": "64.73.192.0/24",
+      "region": "us-gov-west-1",
+      "service": "EC2",
+      "network_border_group": "us-gov-west-1"
     },
     {
       "ip_prefix": "198.41.99.0/24",
@@ -50721,6 +51087,12 @@
       "network_border_group": "ap-east-2"
     },
     {
+      "ip_prefix": "64.66.129.0/24",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ip_prefix": "15.129.30.0/24",
       "region": "sa-east-1",
       "service": "EC2",
@@ -50809,12 +51181,6 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ip_prefix": "35.96.3.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "64.252.105.0/24",
@@ -50920,9 +51286,9 @@
     },
     {
       "ip_prefix": "64.73.201.0/24",
-      "region": "us-east-1",
+      "region": "eu-west-2",
       "service": "EC2",
-      "network_border_group": "us-east-1"
+      "network_border_group": "eu-west-2"
     },
     {
       "ip_prefix": "161.193.128.0/18",
@@ -51105,18 +51471,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ip_prefix": "35.96.0.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.249.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ip_prefix": "46.137.0.0/17",
       "region": "eu-west-1",
       "service": "EC2",
@@ -51127,6 +51481,12 @@
       "region": "eu-south-2",
       "service": "EC2",
       "network_border_group": "eu-south-2"
+    },
+    {
+      "ip_prefix": "64.66.135.0/24",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "99.77.135.0/24",
@@ -51169,12 +51529,6 @@
       "region": "me-south-1",
       "service": "EC2",
       "network_border_group": "me-south-1-mct-1"
-    },
-    {
-      "ip_prefix": "35.96.9.0/24",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ip_prefix": "99.10.0.0/18",
@@ -51289,12 +51643,6 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ip_prefix": "35.96.42.0/24",
-      "region": "ap-south-1",
-      "service": "EC2",
-      "network_border_group": "ap-south-1"
     },
     {
       "ip_prefix": "54.222.58.32/28",
@@ -51520,6 +51868,12 @@
     },
     {
       "ip_prefix": "180.163.57.128/26",
+      "region": "GLOBAL",
+      "service": "CLOUDFRONT",
+      "network_border_group": "GLOBAL"
+    },
+    {
+      "ip_prefix": "1.178.168.0/24",
       "region": "GLOBAL",
       "service": "CLOUDFRONT",
       "network_border_group": "GLOBAL"
@@ -52749,6 +53103,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ip_prefix": "99.83.109.0/24",
+      "region": "eu-south-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "eu-south-1"
+    },
+    {
       "ip_prefix": "3.2.58.0/24",
       "region": "us-east-1",
       "service": "GLOBALACCELERATOR",
@@ -52761,6 +53121,12 @@
       "network_border_group": "ap-south-1"
     },
     {
+      "ip_prefix": "99.83.106.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ip_prefix": "15.197.34.0/23",
       "region": "GLOBAL",
       "service": "GLOBALACCELERATOR",
@@ -52771,6 +53137,12 @@
       "region": "GLOBAL",
       "service": "GLOBALACCELERATOR",
       "network_border_group": "GLOBAL"
+    },
+    {
+      "ip_prefix": "35.34.105.0/24",
+      "region": "eu-west-3",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "eu-west-3"
     },
     {
       "ip_prefix": "13.248.124.0/24",
@@ -52791,10 +53163,22 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ip_prefix": "35.34.102.0/24",
+      "region": "ap-east-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "ap-east-1"
+    },
+    {
       "ip_prefix": "15.197.64.0/19",
       "region": "GLOBAL",
       "service": "GLOBALACCELERATOR",
       "network_border_group": "GLOBAL"
+    },
+    {
+      "ip_prefix": "35.34.104.0/24",
+      "region": "ap-southeast-4",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ip_prefix": "99.83.97.0/24",
@@ -52857,6 +53241,12 @@
       "network_border_group": "ap-northeast-3"
     },
     {
+      "ip_prefix": "99.83.105.0/24",
+      "region": "eu-west-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ip_prefix": "15.197.16.0/23",
       "region": "GLOBAL",
       "service": "GLOBALACCELERATOR",
@@ -52917,10 +53307,22 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ip_prefix": "99.83.108.0/24",
+      "region": "eu-south-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "eu-south-1"
+    },
+    {
       "ip_prefix": "13.248.120.0/24",
       "region": "eu-west-2",
       "service": "GLOBALACCELERATOR",
       "network_border_group": "eu-west-2"
+    },
+    {
+      "ip_prefix": "99.83.107.0/24",
+      "region": "eu-south-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "eu-south-1"
     },
     {
       "ip_prefix": "35.71.128.0/17",
@@ -52945,6 +53347,12 @@
       "region": "us-east-1",
       "service": "GLOBALACCELERATOR",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "35.34.96.0/24",
+      "region": "eu-west-2",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "eu-west-2"
     },
     {
       "ip_prefix": "13.248.96.0/24",
@@ -53059,6 +53467,12 @@
       "region": "sa-east-1",
       "service": "GLOBALACCELERATOR",
       "network_border_group": "sa-east-1"
+    },
+    {
+      "ip_prefix": "35.34.99.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "us-east-1"
     },
     {
       "ip_prefix": "13.248.98.0/24",
@@ -53181,6 +53595,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ip_prefix": "35.34.97.0/24",
+      "region": "us-west-2",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ip_prefix": "13.248.99.0/24",
       "region": "us-west-1",
       "service": "GLOBALACCELERATOR",
@@ -53229,6 +53649,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ip_prefix": "35.34.101.0/24",
+      "region": "us-west-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "us-west-1"
+    },
+    {
       "ip_prefix": "99.83.128.0/17",
       "region": "GLOBAL",
       "service": "GLOBALACCELERATOR",
@@ -53269,6 +53695,18 @@
       "region": "ap-southeast-1",
       "service": "GLOBALACCELERATOR",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ip_prefix": "35.34.100.0/24",
+      "region": "us-east-1",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ip_prefix": "35.34.103.0/24",
+      "region": "ap-northeast-2",
+      "service": "GLOBALACCELERATOR",
+      "network_border_group": "ap-northeast-2"
     },
     {
       "ip_prefix": "3.2.51.0/24",
@@ -61701,6 +62139,126 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ip_prefix": "95.40.214.128/25",
+      "region": "ap-east-1",
+      "service": "EFS",
+      "network_border_group": "ap-east-1"
+    },
+    {
+      "ip_prefix": "54.54.30.0/25",
+      "region": "ap-east-2",
+      "service": "EFS",
+      "network_border_group": "ap-east-2"
+    },
+    {
+      "ip_prefix": "54.116.148.128/25",
+      "region": "ap-northeast-2",
+      "service": "EFS",
+      "network_border_group": "ap-northeast-2"
+    },
+    {
+      "ip_prefix": "16.112.252.128/25",
+      "region": "ap-south-2",
+      "service": "EFS",
+      "network_border_group": "ap-south-2"
+    },
+    {
+      "ip_prefix": "32.236.146.128/25",
+      "region": "ap-southeast-2",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ip_prefix": "16.27.92.0/25",
+      "region": "ap-southeast-4",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ip_prefix": "56.69.91.128/25",
+      "region": "ap-southeast-5",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
+      "ip_prefix": "3.103.180.128/25",
+      "region": "ap-southeast-6",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-6"
+    },
+    {
+      "ip_prefix": "43.210.244.128/25",
+      "region": "ap-southeast-7",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-7"
+    },
+    {
+      "ip_prefix": "16.174.90.128/25",
+      "region": "ca-west-1",
+      "service": "EFS",
+      "network_border_group": "ca-west-1"
+    },
+    {
+      "ip_prefix": "16.18.95.128/25",
+      "region": "eu-central-2",
+      "service": "EFS",
+      "network_border_group": "eu-central-2"
+    },
+    {
+      "ip_prefix": "16.22.121.0/26",
+      "region": "eu-south-1",
+      "service": "EFS",
+      "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "16.22.121.64/28",
+      "region": "eu-south-1",
+      "service": "EFS",
+      "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "16.22.41.144/28",
+      "region": "eu-south-1",
+      "service": "EFS",
+      "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "16.22.41.160/27",
+      "region": "eu-south-1",
+      "service": "EFS",
+      "network_border_group": "eu-south-1"
+    },
+    {
+      "ip_prefix": "35.42.175.0/25",
+      "region": "eu-south-2",
+      "service": "EFS",
+      "network_border_group": "eu-south-2"
+    },
+    {
+      "ip_prefix": "108.133.102.0/25",
+      "region": "eu-west-1",
+      "service": "EFS",
+      "network_border_group": "eu-west-1"
+    },
+    {
+      "ip_prefix": "16.164.136.0/25",
+      "region": "il-central-1",
+      "service": "EFS",
+      "network_border_group": "il-central-1"
+    },
+    {
+      "ip_prefix": "78.14.149.0/25",
+      "region": "mx-central-1",
+      "service": "EFS",
+      "network_border_group": "mx-central-1"
+    },
+    {
+      "ip_prefix": "100.59.224.0/25",
+      "region": "us-east-1",
+      "service": "EFS",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ip_prefix": "43.207.179.168/29",
       "region": "ap-northeast-1",
       "service": "MEDIA_PACKAGE_V2",
@@ -62343,6 +62901,18 @@
       "network_border_group": "ap-southeast-3"
     },
     {
+      "ip_prefix": "35.71.92.0/24",
+      "region": "me-west-1",
+      "service": "DYNAMODB",
+      "network_border_group": "me-west-1"
+    },
+    {
+      "ip_prefix": "13.248.80.0/24",
+      "region": "me-west-1",
+      "service": "DYNAMODB",
+      "network_border_group": "me-west-1"
+    },
+    {
       "ip_prefix": "35.71.123.0/24",
       "region": "ca-west-1",
       "service": "DYNAMODB",
@@ -62541,12 +63111,6 @@
       "network_border_group": "mx-central-1"
     },
     {
-      "ip_prefix": "13.248.80.0/24",
-      "region": "me-west-1",
-      "service": "DYNAMODB",
-      "network_border_group": "me-west-1"
-    },
-    {
       "ip_prefix": "52.82.187.0/24",
       "region": "cn-northwest-1",
       "service": "DYNAMODB",
@@ -62583,12 +63147,6 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
-    },
-    {
-      "ipv6_prefix": "2600:1f01:4900:500::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:9000:5206::/48",
@@ -62861,6 +63419,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2600:1f01:4942::/47",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ipv6_prefix": "2600:1f19:8000::/36",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -62895,12 +63459,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ipv6_prefix": "2631:0:1400::/39",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2a05:d02f::/36",
@@ -62955,6 +63513,12 @@
       "region": "us-gov-west-1",
       "service": "AMAZON",
       "network_border_group": "us-gov-west-1"
+    },
+    {
+      "ipv6_prefix": "2600:9000:de0::/43",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
     },
     {
       "ipv6_prefix": "2600:f0f0:5523::/48",
@@ -63281,18 +63845,6 @@
       "network_border_group": "eu-central-1"
     },
     {
-      "ipv6_prefix": "2631:0:2000::/39",
-      "region": "sa-east-1",
-      "service": "AMAZON",
-      "network_border_group": "sa-east-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:108::/48",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ipv6_prefix": "2a05:d074:9000::/40",
       "region": "eu-central-2",
       "service": "AMAZON",
@@ -63335,6 +63887,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:3001:c000::/52",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d06a:e000::/40",
       "region": "me-south-1",
       "service": "AMAZON",
@@ -63363,12 +63921,6 @@
       "region": "ap-east-1",
       "service": "AMAZON",
       "network_border_group": "ap-east-1"
-    },
-    {
-      "ipv6_prefix": "2600:1f01:4900:900::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:1f01:491e::/47",
@@ -63407,16 +63959,34 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4f:8000::/60",
+      "region": "us-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-west-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b80::/44",
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
     },
     {
+      "ipv6_prefix": "2606:7b40:300b::/54",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d070:4000::/40",
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4944::/47",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:f0f0:e14::/48",
@@ -63429,12 +63999,6 @@
       "region": "ap-southeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3002:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d03a:4000::/40",
@@ -63501,6 +64065,12 @@
       "region": "ap-southeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a3f:c000::/60",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2606:7b40:1b05:4000::/56",
@@ -63707,12 +64277,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3003:8000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2620:107:4000:9015::/64",
       "region": "ca-central-1",
       "service": "AMAZON",
@@ -63771,6 +64335,12 @@
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5407::/48",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f3:f010::/56",
@@ -64073,6 +64643,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ipv6_prefix": "2600:f0f0:5408::/48",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:6108::/48",
       "region": "eu-west-2",
       "service": "AMAZON",
@@ -64149,6 +64725,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4e:340::/60",
+      "region": "ca-central-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-central-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b20::/44",
@@ -64337,6 +64919,12 @@
       "network_border_group": "ap-southeast-2"
     },
     {
+      "ipv6_prefix": "2600:1f01:4946::/47",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ipv6_prefix": "2600:1f18::/33",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -64347,6 +64935,12 @@
       "region": "us-west-1",
       "service": "AMAZON",
       "network_border_group": "us-west-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a49:340::/60",
+      "region": "sa-east-1",
+      "service": "AMAZON",
+      "network_border_group": "sa-east-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b0d:c000::/56",
@@ -64373,7 +64967,7 @@
       "network_border_group": "me-central-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3002:c000::/50",
+      "ipv6_prefix": "2606:7b40:1a3f:c240::/60",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -64469,18 +65063,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2631:0:800::/39",
-      "region": "ca-central-1",
-      "service": "AMAZON",
-      "network_border_group": "ca-central-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:10c::/48",
-      "region": "ca-central-1",
-      "service": "AMAZON",
-      "network_border_group": "ca-central-1"
-    },
-    {
       "ipv6_prefix": "2a05:d032:e000::/40",
       "region": "me-south-1",
       "service": "AMAZON",
@@ -64527,6 +65109,12 @@
       "region": "ap-southeast-4",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4d:c000::/60",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
     },
     {
       "ipv6_prefix": "2606:7b40:1a4f:c240::/60",
@@ -64617,24 +65205,6 @@
       "region": "us-west-1",
       "service": "AMAZON",
       "network_border_group": "us-west-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3002::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3004:8000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3005:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2620:107:4000:4::/64",
@@ -64925,6 +65495,18 @@
       "network_border_group": "ca-central-1"
     },
     {
+      "ipv6_prefix": "2600:9000:ff8::/46",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
+    },
+    {
+      "ipv6_prefix": "2600:f008:100::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:0:300::/56",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -64947,6 +65529,12 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5406::/48",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:8120::/48",
@@ -65009,12 +65597,6 @@
       "network_border_group": "ap-southeast-2"
     },
     {
-      "ipv6_prefix": "2600:1f01:4900:600::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ipv6_prefix": "2600:9000:ae00::/40",
       "region": "GLOBAL",
       "service": "AMAZON",
@@ -65031,6 +65613,12 @@
       "region": "ap-south-1",
       "service": "AMAZON",
       "network_border_group": "ap-south-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f2:7400::/38",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
     },
     {
       "ipv6_prefix": "2a05:d000:9000::/40",
@@ -65085,6 +65673,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a47:4000::/60",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2606:7b40:1b30::/44",
@@ -65205,6 +65799,12 @@
       "region": "sa-east-1",
       "service": "AMAZON",
       "network_border_group": "sa-east-1"
+    },
+    {
+      "ipv6_prefix": "2605:b140:9805::/48",
+      "region": "ca-west-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-west-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:fa00::/56",
@@ -65525,6 +66125,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ipv6_prefix": "2606:f40:4b00::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2606:f40:fff8::/48",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -65619,6 +66225,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f:4340::/60",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
     },
     {
       "ipv6_prefix": "2620:107:4000:900f::/64",
@@ -65765,22 +66377,16 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4c:c000::/60",
+      "region": "eu-south-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-1"
+    },
+    {
       "ipv6_prefix": "2620:107:4000:4701::/64",
       "region": "us-east-2",
       "service": "AMAZON",
       "network_border_group": "us-east-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:a::/48",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:2400::/39",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2a05:d074:b000::/40",
@@ -65835,6 +66441,12 @@
       "region": "eu-west-2",
       "service": "AMAZON",
       "network_border_group": "eu-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:300a::/56",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2400:6500:0:9::1/128",
@@ -65895,6 +66507,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a45:c340::/60",
+      "region": "ap-northeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-northeast-1"
     },
     {
       "ipv6_prefix": "2a05:d06a:2000::/40",
@@ -65963,6 +66581,12 @@
       "network_border_group": "af-south-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4c:340::/60",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2a05:d06b:800::/40",
       "region": "me-west-1",
       "service": "AMAZON",
@@ -65973,6 +66597,12 @@
       "region": "me-central-1",
       "service": "AMAZON",
       "network_border_group": "me-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4938::/47",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
     },
     {
       "ipv6_prefix": "2600:1ffc:5000::/40",
@@ -66011,12 +66641,6 @@
       "network_border_group": "ap-southeast-3"
     },
     {
-      "ipv6_prefix": "2600:1f01:4900:300::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ipv6_prefix": "2600:1ff9:1000::/40",
       "region": "ca-central-1",
       "service": "AMAZON",
@@ -66039,6 +66663,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a46:8000::/60",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
     },
     {
       "ipv6_prefix": "2a05:d026::/36",
@@ -66069,6 +66699,12 @@
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4902:2::/65",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2600:1f70:1000::/40",
@@ -66108,6 +66744,12 @@
     },
     {
       "ipv6_prefix": "2606:7b40:10ff::/59",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a1f:c340::/60",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -66317,12 +66959,6 @@
       "network_border_group": "us-west-2-sea-1"
     },
     {
-      "ipv6_prefix": "2631:1:106::/48",
-      "region": "sa-east-1",
-      "service": "AMAZON",
-      "network_border_group": "sa-east-1"
-    },
-    {
       "ipv6_prefix": "2a01:578:0:7500::1/128",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -66453,12 +67089,6 @@
       "region": "eu-west-2",
       "service": "AMAZON",
       "network_border_group": "eu-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:7::/48",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
     },
     {
       "ipv6_prefix": "2a05:d030:a000::/40",
@@ -66671,6 +67301,12 @@
       "network_border_group": "sa-east-1"
     },
     {
+      "ipv6_prefix": "2600:f0f0:4200::/40",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:8104::/48",
       "region": "ap-southeast-7",
       "service": "AMAZON",
@@ -66849,12 +67485,6 @@
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
-    },
-    {
-      "ipv6_prefix": "2631:0:2600::/39",
-      "region": "ap-southeast-2",
-      "service": "AMAZON",
-      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2400:6500:0:7200::/56",
@@ -67121,6 +67751,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1000:6240::/60",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1000:7200::/60",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -67137,12 +67773,6 @@
       "region": "ca-central-1",
       "service": "AMAZON",
       "network_border_group": "ca-central-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d05a:800::/40",
@@ -67221,6 +67851,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2-hnl-1"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4902::/48",
+      "region": "eu-south-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-2"
     },
     {
       "ipv6_prefix": "2606:8140:200::/40",
@@ -67361,6 +67997,12 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ipv6_prefix": "2600:f0f0:e38::/48",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:4141::/48",
       "region": "us-gov-east-1",
       "service": "AMAZON",
@@ -67407,12 +68049,6 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:8::/48",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2a05:d028:8000::/36",
@@ -67467,6 +68103,12 @@
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f::/60",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b06:4000::/56",
@@ -67907,12 +68549,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3006::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2620:107:4000:8001::/64",
       "region": "us-east-1",
       "service": "AMAZON",
@@ -68009,6 +68645,30 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ipv6_prefix": "2606:f40:4903::/48",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a49::/60",
+      "region": "sa-east-1",
+      "service": "AMAZON",
+      "network_border_group": "sa-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4d::/60",
+      "region": "eu-south-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f:4240::/60",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2a05:d016::/36",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -68082,18 +68742,6 @@
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:c300::/56",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3003:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:2::/48",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -68255,6 +68903,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4d:4000::/60",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b06:8000::/56",
       "region": "ap-south-1",
       "service": "AMAZON",
@@ -68387,12 +69041,6 @@
       "network_border_group": "sa-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3008::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d032:2000::/40",
       "region": "eu-west-3",
       "service": "AMAZON",
@@ -68478,6 +69126,12 @@
     },
     {
       "ipv6_prefix": "2606:f40:5000::/39",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1b0d:4200::/56",
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
@@ -68607,18 +69261,6 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3007:c000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:1:107::/48",
-      "region": "ap-southeast-2",
-      "service": "AMAZON",
-      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2804:800:ff00::/48",
@@ -68801,12 +69443,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2631:1:10b::/48",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
-    },
-    {
       "ipv6_prefix": "2a05:d030:2000::/40",
       "region": "eu-west-3",
       "service": "AMAZON",
@@ -68939,7 +69575,19 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:f40:4901::/48",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0f:c200::/56",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:3001:8000::/52",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -68985,6 +69633,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:e36::/48",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2620:107:4000:2::/64",
@@ -69039,18 +69693,6 @@
       "region": "us-east-2",
       "service": "AMAZON",
       "network_border_group": "us-east-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3001:c000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3005:c000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d050:5000::/40",
@@ -69155,12 +69797,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3004:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d022::/36",
       "region": "eu-west-3",
       "service": "AMAZON",
@@ -69216,6 +69852,12 @@
     },
     {
       "ipv6_prefix": "2600:f0f0:0:21c::/62",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f3:f010:300::/56",
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
@@ -69303,12 +69945,6 @@
       "region": "us-gov-west-1",
       "service": "AMAZON",
       "network_border_group": "us-gov-west-1"
-    },
-    {
-      "ipv6_prefix": "2600:1f01:4900:a00::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:1feb:8000::/39",
@@ -69491,12 +70127,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2631:0:600::/39",
-      "region": "eu-west-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-2"
-    },
-    {
       "ipv6_prefix": "2a01:578:0:7400::/56",
       "region": "eu-south-1",
       "service": "AMAZON",
@@ -69545,6 +70175,12 @@
       "network_border_group": "ap-southeast-4"
     },
     {
+      "ipv6_prefix": "2600:1f01:4902:3:8000::/65",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2600:1fef:2000::/40",
       "region": "us-gov-west-1",
       "service": "AMAZON",
@@ -69567,12 +70203,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3006:8000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d031:2000::/40",
@@ -69671,6 +70301,12 @@
       "network_border_group": "ca-central-1"
     },
     {
+      "ipv6_prefix": "2606:f40:4200::/40",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d068:800::/40",
       "region": "me-west-1",
       "service": "AMAZON",
@@ -69719,16 +70355,22 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4d:8340::/60",
+      "region": "eu-west-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f:c000::/60",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2620:107:4000:8500::/56",
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ipv6_prefix": "2631:0:3::/48",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2a05:d079:4000::/40",
@@ -69791,12 +70433,6 @@
       "network_border_group": "eu-central-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3004:c000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2620:107:4000:4204::/64",
       "region": "us-west-1",
       "service": "AMAZON",
@@ -69804,12 +70440,6 @@
     },
     {
       "ipv6_prefix": "2620:107:4000:9900:50:82::/96",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:1::/48",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -69875,6 +70505,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4e::/60",
+      "region": "ca-central-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-central-1"
+    },
+    {
       "ipv6_prefix": "2404:c2c0:3100::/40",
       "region": "cn-northwest-1",
       "service": "AMAZON",
@@ -69891,12 +70527,6 @@
       "region": "af-south-1",
       "service": "AMAZON",
       "network_border_group": "af-south-1"
-    },
-    {
-      "ipv6_prefix": "2600:1f01:4900:700::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:1f26:c000::/36",
@@ -70187,6 +70817,12 @@
       "network_border_group": "ap-south-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a45:c000::/60",
+      "region": "ap-northeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-northeast-1"
+    },
+    {
       "ipv6_prefix": "2620:107:4000:9014::/64",
       "region": "ca-central-1",
       "service": "AMAZON",
@@ -70241,12 +70877,6 @@
       "network_border_group": "us-gov-east-1"
     },
     {
-      "ipv6_prefix": "2631:0:9::/48",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d06a:4000::/40",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -70275,12 +70905,6 @@
       "region": "ap-south-1",
       "service": "AMAZON",
       "network_border_group": "ap-south-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3005::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d032:a000::/40",
@@ -70323,6 +70947,12 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4e:4000::/60",
+      "region": "ca-west-1",
+      "service": "AMAZON",
+      "network_border_group": "ca-west-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b05:c100::/56",
@@ -70409,6 +71039,12 @@
       "network_border_group": "ap-east-2"
     },
     {
+      "ipv6_prefix": "2600:1f01:4930::/47",
+      "region": "us-west-1",
+      "service": "AMAZON",
+      "network_border_group": "us-west-1"
+    },
+    {
       "ipv6_prefix": "2600:1ff8:4000::/39",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -70473,6 +71109,12 @@
       "region": "sa-west-1",
       "service": "AMAZON",
       "network_border_group": "sa-west-1"
+    },
+    {
+      "ipv6_prefix": "2600:9000:fc0::/43",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
     },
     {
       "ipv6_prefix": "2600:9000:a400::/40",
@@ -70635,6 +71277,12 @@
       "region": "us-east-2",
       "service": "AMAZON",
       "network_border_group": "us-east-2"
+    },
+    {
+      "ipv6_prefix": "2600:f008:200::/40",
+      "region": "eu-south-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-2"
     },
     {
       "ipv6_prefix": "2600:f0f1:41c0::/42",
@@ -71027,12 +71675,6 @@
       "network_border_group": "ap-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3006:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d06f:9000::/40",
       "region": "eu-central-2",
       "service": "AMAZON",
@@ -71327,12 +71969,6 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ipv6_prefix": "2631:0:e00::/39",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ipv6_prefix": "2a05:d059:4000::/40",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -71375,10 +72011,22 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ipv6_prefix": "2600:f0f0:7::/48",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:e1f::/48",
       "region": "me-south-1",
       "service": "AMAZON",
       "network_border_group": "me-south-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0fb:c001::/56",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:f40:5800::/40",
@@ -71507,6 +72155,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ipv6_prefix": "2600:f008:400::/40",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2600:f00e::/39",
       "region": "eu-west-1",
       "service": "AMAZON",
@@ -71523,12 +72177,6 @@
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3007:8000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d073:1000::/40",
@@ -71891,12 +72539,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2631:0:a00::/39",
-      "region": "us-east-2",
-      "service": "AMAZON",
-      "network_border_group": "us-east-2"
-    },
-    {
       "ipv6_prefix": "2406:da33:4000::/40",
       "region": "ap-northeast-1",
       "service": "AMAZON",
@@ -71943,6 +72585,12 @@
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4d:c340::/60",
+      "region": "eu-west-3",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-3"
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:fd00::/56",
@@ -71993,12 +72641,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2631:0:1200::/39",
-      "region": "sa-east-1",
-      "service": "AMAZON",
-      "network_border_group": "sa-east-1"
-    },
-    {
       "ipv6_prefix": "2a05:d033:4000::/40",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -72023,7 +72665,7 @@
       "network_border_group": "us-west-2-phx-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3004::/50",
+      "ipv6_prefix": "2606:7b40:1a4f:c340::/60",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -72033,12 +72675,6 @@
       "region": "us-west-1",
       "service": "AMAZON",
       "network_border_group": "us-west-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:10f::/48",
-      "region": "eu-west-3",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-3"
     },
     {
       "ipv6_prefix": "2406:da33:b000::/40",
@@ -72179,22 +72815,16 @@
       "network_border_group": "us-east-1-chi-1"
     },
     {
+      "ipv6_prefix": "2606:f40:4600::/40",
+      "region": "eu-south-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-south-2"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1a2f:c200::/60",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:4::/48",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
-    },
-    {
-      "ipv6_prefix": "2631:0:c00::/39",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2a05:d038:e000::/40",
@@ -72347,6 +72977,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4f:4000::/60",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2620:107:4000:9900:50:83::/96",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -72485,6 +73121,12 @@
       "network_border_group": "ap-northeast-2"
     },
     {
+      "ipv6_prefix": "2606:f40:4300::/40",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:a3e:c00::/54",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -72611,6 +73253,12 @@
       "network_border_group": "ap-southeast-7"
     },
     {
+      "ipv6_prefix": "2600:1f01:4902:2:8000::/65",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2600:1f70:7400::/40",
       "region": "mx-central-1",
       "service": "AMAZON",
@@ -72687,12 +73335,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3000:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a01:578:0:7600::1/128",
@@ -72918,12 +73560,6 @@
     },
     {
       "ipv6_prefix": "2606:7b40:10ff:ff00::/56",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3003:c000::/50",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -73511,6 +74147,12 @@
       "network_border_group": "ap-northeast-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:3009:c000::/52",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d070:6000::/40",
       "region": "eu-north-1",
       "service": "AMAZON",
@@ -73553,10 +74195,10 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3002:8000::/50",
-      "region": "us-west-2",
+      "ipv6_prefix": "2600:f0fb:c002::/56",
+      "region": "us-east-1",
       "service": "AMAZON",
-      "network_border_group": "us-west-2"
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2620:107:4000:7a00::/56",
@@ -73611,12 +74253,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:10d::/48",
-      "region": "eu-west-2",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-2"
     },
     {
       "ipv6_prefix": "2a05:d040:4000::/40",
@@ -73781,6 +74417,12 @@
       "network_border_group": "ap-southeast-6"
     },
     {
+      "ipv6_prefix": "2600:1f01:4932::/47",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ipv6_prefix": "2600:1f32:800::/40",
       "region": "us-south-1",
       "service": "AMAZON",
@@ -73841,10 +74483,28 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a3f:4240::/60",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:3002::/56",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2406:da32:a000::/40",
       "region": "ap-south-1",
       "service": "AMAZON",
       "network_border_group": "ap-south-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:4940::/47",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:1f24::/36",
@@ -73899,12 +74559,6 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ipv6_prefix": "2631:0:200::/39",
-      "region": "eu-central-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2a05:d059:8000::/40",
@@ -74075,6 +74729,12 @@
       "network_border_group": "ap-southeast-1"
     },
     {
+      "ipv6_prefix": "2600:1f01:493e::/47",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ipv6_prefix": "2600:1f10:8000::/36",
       "region": "us-south-1",
       "service": "AMAZON",
@@ -74111,16 +74771,22 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a3f:c340::/60",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4c::/60",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b50::/44",
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3007::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d06f:b000::/40",
@@ -74375,12 +75041,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3001:8000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2400:7fc0:f300::/40",
       "region": "cn-north-1",
       "service": "AMAZON",
@@ -74567,12 +75227,6 @@
       "network_border_group": "ap-northeast-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3003::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2620:107:4000:7c00::/56",
       "region": "ca-west-1",
       "service": "AMAZON",
@@ -74643,6 +75297,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1b07:200::/56",
+      "region": "ap-southeast-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-1"
     },
     {
       "ipv6_prefix": "2620:107:4000:a840::/58",
@@ -74831,10 +75491,10 @@
       "network_border_group": "ap-southeast-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3005:8000::/50",
-      "region": "us-west-2",
+      "ipv6_prefix": "2606:7b40:1a47:4340::/60",
+      "region": "ap-southeast-2",
       "service": "AMAZON",
-      "network_border_group": "us-west-2"
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2620:107:4004::/48",
@@ -74865,6 +75525,12 @@
       "region": "ap-east-1",
       "service": "AMAZON",
       "network_border_group": "ap-east-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:493a::/47",
+      "region": "eu-west-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:e13::/48",
@@ -74955,12 +75621,6 @@
       "region": "eu-south-1",
       "service": "AMAZON",
       "network_border_group": "eu-south-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3007:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2620:107:4000:4704::/64",
@@ -75077,6 +75737,12 @@
       "network_border_group": "ap-southeast-6"
     },
     {
+      "ipv6_prefix": "2600:1f01:4902:3::/65",
+      "region": "eu-central-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2600:1ff2:c000::/40",
       "region": "us-west-1",
       "service": "AMAZON",
@@ -75191,6 +75857,12 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ipv6_prefix": "2600:9000:7000::/36",
+      "region": "GLOBAL",
+      "service": "AMAZON",
+      "network_border_group": "GLOBAL"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:1126::/48",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -75239,6 +75911,12 @@
       "network_border_group": "eu-central-1"
     },
     {
+      "ipv6_prefix": "2600:1f01:4948::/47",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ipv6_prefix": "2600:1fa0:7400::/40",
       "region": "mx-central-1",
       "service": "AMAZON",
@@ -75267,6 +75945,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:e37::/48",
+      "region": "ap-southeast-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:5402::/48",
@@ -75449,12 +76133,6 @@
       "network_border_group": "eu-west-3"
     },
     {
-      "ipv6_prefix": "2631:0:400::/39",
-      "region": "eu-west-3",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-3"
-    },
-    {
       "ipv6_prefix": "2a05:d031:4000::/40",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -75585,6 +76263,12 @@
       "region": "eu-central-1",
       "service": "AMAZON",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5409::/48",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:c004::/48",
@@ -76007,12 +76691,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3001:4000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2406:da70:2000::/40",
       "region": "ap-northeast-2",
       "service": "AMAZON",
@@ -76079,19 +76757,7 @@
       "network_border_group": "ca-west-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3006:c000::/50",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2606:7b40:f000:1600::/56",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:1800::/39",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -76157,6 +76823,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4f:340::/60",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b00:700::/56",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -76203,6 +76875,12 @@
       "region": "us-east-1",
       "service": "AMAZON",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4900::/48",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d072:1000::/40",
@@ -76259,12 +76937,6 @@
       "network_border_group": "ap-south-2"
     },
     {
-      "ipv6_prefix": "2631:0:1000::/39",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
-    },
-    {
       "ipv6_prefix": "2a05:d029::/36",
       "region": "eu-central-2",
       "service": "AMAZON",
@@ -76305,6 +76977,12 @@
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a46:c000::/60",
+      "region": "ap-south-2",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-2"
     },
     {
       "ipv6_prefix": "2606:7b40:1b09:200::/56",
@@ -76437,6 +77115,12 @@
       "region": "GLOBAL",
       "service": "AMAZON",
       "network_border_group": "GLOBAL"
+    },
+    {
+      "ipv6_prefix": "2600:f0fb:c800::/56",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:7b40:a3e:280::/60",
@@ -76667,12 +77351,6 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ipv6_prefix": "2631::/48",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d03a:9000::/40",
       "region": "eu-central-2",
       "service": "AMAZON",
@@ -76727,10 +77405,10 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ipv6_prefix": "2631:0:2200::/39",
-      "region": "sa-east-1",
+      "ipv6_prefix": "2606:7b40:3000:8000::/52",
+      "region": "us-west-2",
       "service": "AMAZON",
-      "network_border_group": "sa-east-1"
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d050:8000::/40",
@@ -76817,16 +77495,16 @@
       "network_border_group": "us-gov-west-1"
     },
     {
-      "ipv6_prefix": "2631:1:101::/48",
-      "region": "eu-west-1",
-      "service": "AMAZON",
-      "network_border_group": "eu-west-1"
-    },
-    {
       "ipv6_prefix": "2406:dae9:8800::/40",
       "region": "ap-southeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f01:493c::/47",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2600:1ff0:c000::/40",
@@ -76937,6 +77615,12 @@
       "network_border_group": "eu-central-1"
     },
     {
+      "ipv6_prefix": "2600:1f01:4936::/47",
+      "region": "ap-south-1",
+      "service": "AMAZON",
+      "network_border_group": "ap-south-1"
+    },
+    {
       "ipv6_prefix": "2600:1f30:7400::/40",
       "region": "mx-central-1",
       "service": "AMAZON",
@@ -76997,12 +77681,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2631:1:200::/40",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2406:da32:9000::/40",
       "region": "ap-southeast-3",
       "service": "AMAZON",
@@ -77019,6 +77697,12 @@
       "region": "ap-southeast-4",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ipv6_prefix": "2600:1f12:2000::/36",
+      "region": "us-south-1",
+      "service": "AMAZON",
+      "network_border_group": "us-south-1"
     },
     {
       "ipv6_prefix": "2600:1fba:4000::/39",
@@ -77055,6 +77739,12 @@
       "region": "eu-west-1",
       "service": "AMAZON",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a47:c000::/60",
+      "region": "ap-southeast-4",
+      "service": "AMAZON",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ipv6_prefix": "2606:7b40:1b0d:c100::/56",
@@ -77103,6 +77793,12 @@
       "region": "ap-southeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4700::/40",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2a05:d06f:6000::/40",
@@ -77309,10 +78005,10 @@
       "network_border_group": "eu-west-3"
     },
     {
-      "ipv6_prefix": "2606:7b40:3001::/50",
-      "region": "us-west-2",
+      "ipv6_prefix": "2606:f40:4904::/48",
+      "region": "eu-west-1",
       "service": "AMAZON",
-      "network_border_group": "us-west-2"
+      "network_border_group": "eu-west-1"
     },
     {
       "ipv6_prefix": "2620:107:4000:5::/64",
@@ -77345,6 +78041,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ipv6_prefix": "2600:f008::/40",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:8185::/48",
       "region": "ap-southeast-2",
       "service": "AMAZON",
@@ -77357,16 +78059,16 @@
       "network_border_group": "ap-northeast-3"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4d:8000::/60",
+      "region": "eu-west-2",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-2"
+    },
+    {
       "ipv6_prefix": "2620:107:4000:4105::/64",
       "region": "us-west-1",
       "service": "AMAZON",
       "network_border_group": "us-west-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:105::/48",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a01:578:0:7601::1/128",
@@ -77489,6 +78191,12 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ipv6_prefix": "2600:1f01:4934::/47",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2600:1ffd:80cb::/48",
       "region": "eu-central-1",
       "service": "AMAZON",
@@ -77508,12 +78216,6 @@
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:f800::/56",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3000:c000::/50",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -77649,12 +78351,6 @@
       "region": "ap-southeast-2",
       "service": "AMAZON",
       "network_border_group": "ap-southeast-2"
-    },
-    {
-      "ipv6_prefix": "2600:1f01:4900:400::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:1fb9:a400::/40",
@@ -77909,6 +78605,12 @@
       "network_border_group": "eu-south-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a2f:c340::/60",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2620:107:4000:9900:50:84::/96",
       "region": "us-west-2",
       "service": "AMAZON",
@@ -77982,12 +78684,6 @@
     },
     {
       "ipv6_prefix": "2606:7b40:1000:7000::/56",
-      "region": "us-west-2",
-      "service": "AMAZON",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:1600::/39",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -78215,6 +78911,12 @@
       "network_border_group": "eu-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4d:4340::/60",
+      "region": "eu-west-1",
+      "service": "AMAZON",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0d:8000::/56",
       "region": "eu-west-2",
       "service": "AMAZON",
@@ -78281,16 +78983,16 @@
       "network_border_group": "ap-south-2"
     },
     {
-      "ipv6_prefix": "2600:1f01:4900:b00::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
-    },
-    {
       "ipv6_prefix": "2600:f004::/40",
       "region": "ap-northeast-1",
       "service": "AMAZON",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ipv6_prefix": "2600:f008:300::/40",
+      "region": "us-east-1",
+      "service": "AMAZON",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:f40:8800::/40",
@@ -78339,12 +79041,6 @@
       "region": "ca-west-1",
       "service": "AMAZON",
       "network_border_group": "ca-west-1"
-    },
-    {
-      "ipv6_prefix": "2600:1f01:4900:800::/56",
-      "region": "us-east-1",
-      "service": "AMAZON",
-      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2600:1fe9:e000::/40",
@@ -78408,6 +79104,12 @@
     },
     {
       "ipv6_prefix": "2606:7b40:a3e:270::/60",
+      "region": "us-west-2",
+      "service": "AMAZON",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a2f:c240::/60",
       "region": "us-west-2",
       "service": "AMAZON",
       "network_border_group": "us-west-2"
@@ -78525,6 +79227,12 @@
       "region": "sa-east-1",
       "service": "AMAZON",
       "network_border_group": "sa-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:10f4:3240::/60",
+      "region": "us-east-2",
+      "service": "AMAZON",
+      "network_border_group": "us-east-2"
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:600::/56",
@@ -80115,6 +80823,12 @@
       "region": "us-west-1",
       "service": "S3",
       "network_border_group": "us-west-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:4200::/40",
+      "region": "us-east-2",
+      "service": "S3",
+      "network_border_group": "us-east-2"
     },
     {
       "ipv6_prefix": "2406:dab9:c800::/40",
@@ -82541,6 +83255,18 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ipv6_prefix": "2600:f0f0:5407::/48",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5408::/48",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:11fe::/48",
       "region": "us-west-2",
       "service": "IVS_REALTIME",
@@ -82593,6 +83319,12 @@
       "region": "ap-southeast-1",
       "service": "IVS_REALTIME",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5406::/48",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:110d::/48",
@@ -82733,6 +83465,12 @@
       "network_border_group": "ap-south-1"
     },
     {
+      "ipv6_prefix": "2600:f0f0:e38::/48",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:1101::/48",
       "region": "ap-northeast-1",
       "service": "IVS_REALTIME",
@@ -82851,6 +83589,12 @@
       "region": "us-west-2",
       "service": "IVS_REALTIME",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:e36::/48",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:5521::/48",
@@ -83177,10 +83921,22 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2600:f0f0:e37::/48",
+      "region": "ap-southeast-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:5402::/48",
       "region": "ap-northeast-2",
       "service": "IVS_REALTIME",
       "network_border_group": "ap-northeast-2"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5409::/48",
+      "region": "us-west-2",
+      "service": "IVS_REALTIME",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:e0a::/48",
@@ -84161,12 +84917,6 @@
       "network_border_group": "eu-central-1"
     },
     {
-      "ipv6_prefix": "2631:1:108::/48",
-      "region": "eu-central-1",
-      "service": "EC2",
-      "network_border_group": "eu-central-1"
-    },
-    {
       "ipv6_prefix": "2a05:d074:9000::/40",
       "region": "eu-central-2",
       "service": "EC2",
@@ -84195,6 +84945,12 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:3001:c000::/52",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d06a:e000::/40",
@@ -84233,6 +84989,18 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4f:8000::/60",
+      "region": "us-west-1",
+      "service": "EC2",
+      "network_border_group": "us-west-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:300b::/54",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d070:4000::/40",
       "region": "eu-central-1",
       "service": "EC2",
@@ -84249,12 +85017,6 @@
       "region": "ap-southeast-2",
       "service": "EC2",
       "network_border_group": "ap-southeast-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3002:4000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d03a:4000::/40",
@@ -84315,6 +85077,12 @@
       "region": "ap-southeast-2",
       "service": "EC2",
       "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a3f:c000::/60",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2606:7b40:1b05:4000::/56",
@@ -84485,12 +85253,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3003:8000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d036:e000::/40",
       "region": "me-south-1",
       "service": "EC2",
@@ -84531,6 +85293,12 @@
       "region": "eu-central-1",
       "service": "EC2",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5407::/48",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f3:f010::/56",
@@ -84761,6 +85529,12 @@
       "network_border_group": "us-east-1-chi-2"
     },
     {
+      "ipv6_prefix": "2600:f0f0:5408::/48",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:6108::/48",
       "region": "eu-west-2",
       "service": "EC2",
@@ -84837,6 +85611,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4e:340::/60",
+      "region": "ca-central-1",
+      "service": "EC2",
+      "network_border_group": "ca-central-1"
     },
     {
       "ipv6_prefix": "2400:6500:ff00::/48",
@@ -84977,6 +85757,12 @@
       "network_border_group": "us-west-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a49:340::/60",
+      "region": "sa-east-1",
+      "service": "EC2",
+      "network_border_group": "sa-east-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0d:c000::/56",
       "region": "eu-west-3",
       "service": "EC2",
@@ -84995,7 +85781,7 @@
       "network_border_group": "me-central-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3002:c000::/50",
+      "ipv6_prefix": "2606:7b40:1a3f:c240::/60",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -85055,12 +85841,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2631:1:10c::/48",
-      "region": "ca-central-1",
-      "service": "EC2",
-      "network_border_group": "ca-central-1"
-    },
-    {
       "ipv6_prefix": "2a05:d032:e000::/40",
       "region": "me-south-1",
       "service": "EC2",
@@ -85101,6 +85881,12 @@
       "region": "ap-southeast-4",
       "service": "EC2",
       "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4d:c000::/60",
+      "region": "eu-west-3",
+      "service": "EC2",
+      "network_border_group": "eu-west-3"
     },
     {
       "ipv6_prefix": "2606:7b40:1a4f:c240::/60",
@@ -85173,24 +85959,6 @@
       "region": "us-west-1",
       "service": "EC2",
       "network_border_group": "us-west-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3002::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3004:8000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3005:4000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a01:578:13::/48",
@@ -85421,6 +86189,12 @@
       "network_border_group": "ca-central-1"
     },
     {
+      "ipv6_prefix": "2600:f008:100::/40",
+      "region": "eu-central-1",
+      "service": "EC2",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:0:300::/56",
       "region": "us-west-2",
       "service": "EC2",
@@ -85443,6 +86217,12 @@
       "region": "ap-southeast-1",
       "service": "EC2",
       "network_border_group": "ap-southeast-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5406::/48",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:8120::/48",
@@ -85493,6 +86273,12 @@
       "network_border_group": "ap-south-1"
     },
     {
+      "ipv6_prefix": "2600:f0f2:7400::/38",
+      "region": "GLOBAL",
+      "service": "EC2",
+      "network_border_group": "GLOBAL"
+    },
+    {
       "ipv6_prefix": "2a05:d000:9000::/40",
       "region": "eu-central-2",
       "service": "EC2",
@@ -85533,6 +86319,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a47:4000::/60",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2a05:d030:c000::/40",
@@ -85617,6 +86409,12 @@
       "region": "sa-east-1",
       "service": "EC2",
       "network_border_group": "sa-east-1"
+    },
+    {
+      "ipv6_prefix": "2605:b140:9805::/48",
+      "region": "ca-west-1",
+      "service": "EC2",
+      "network_border_group": "ca-west-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:fa00::/56",
@@ -85871,6 +86669,12 @@
       "network_border_group": "GLOBAL"
     },
     {
+      "ipv6_prefix": "2606:f40:4b00::/40",
+      "region": "eu-west-1",
+      "service": "EC2",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2606:f40:fff8::/48",
       "region": "eu-central-1",
       "service": "EC2",
@@ -85947,6 +86751,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f:4340::/60",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
     },
     {
       "ipv6_prefix": "2a05:d021::/36",
@@ -86075,10 +86885,10 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ipv6_prefix": "2631:0:a::/48",
-      "region": "us-west-2",
+      "ipv6_prefix": "2606:7b40:1a4c:c000::/60",
+      "region": "eu-south-1",
       "service": "EC2",
-      "network_border_group": "us-west-2"
+      "network_border_group": "eu-south-1"
     },
     {
       "ipv6_prefix": "2a05:d074:b000::/40",
@@ -86123,6 +86933,12 @@
       "network_border_group": "eu-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:300a::/56",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2406:da00:f000::/40",
       "region": "ap-southeast-4",
       "service": "EC2",
@@ -86163,6 +86979,12 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a45:c340::/60",
+      "region": "ap-northeast-1",
+      "service": "EC2",
+      "network_border_group": "ap-northeast-1"
     },
     {
       "ipv6_prefix": "2a05:d06a:2000::/40",
@@ -86219,6 +87041,12 @@
       "network_border_group": "af-south-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4c:340::/60",
+      "region": "eu-central-1",
+      "service": "EC2",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2a05:d06b:800::/40",
       "region": "me-west-1",
       "service": "EC2",
@@ -86259,6 +87087,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a46:8000::/60",
+      "region": "ap-south-1",
+      "service": "EC2",
+      "network_border_group": "ap-south-1"
     },
     {
       "ipv6_prefix": "2a05:d026::/36",
@@ -86316,6 +87150,12 @@
     },
     {
       "ipv6_prefix": "2606:7b40:10ff::/59",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a1f:c340::/60",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -86463,12 +87303,6 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2-sea-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:106::/48",
-      "region": "sa-east-1",
-      "service": "EC2",
-      "network_border_group": "sa-east-1"
     },
     {
       "ipv6_prefix": "2a05:d033:5000::/40",
@@ -86745,6 +87579,12 @@
       "region": "sa-east-1",
       "service": "EC2",
       "network_border_group": "sa-east-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:4200::/40",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:8104::/48",
@@ -87071,6 +87911,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1000:6240::/60",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1000:7200::/60",
       "region": "us-west-2",
       "service": "EC2",
@@ -87087,12 +87933,6 @@
       "region": "ca-central-1",
       "service": "EC2",
       "network_border_group": "ca-central-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d05a:800::/40",
@@ -87159,6 +87999,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2-hnl-1"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4902::/48",
+      "region": "eu-south-2",
+      "service": "EC2",
+      "network_border_group": "eu-south-2"
     },
     {
       "ipv6_prefix": "2606:8140:200::/40",
@@ -87287,6 +88133,12 @@
       "network_border_group": "us-east-2"
     },
     {
+      "ipv6_prefix": "2600:f0f0:e38::/48",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:4141::/48",
       "region": "us-gov-east-1",
       "service": "EC2",
@@ -87375,6 +88227,12 @@
       "region": "eu-central-1",
       "service": "EC2",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f::/60",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b06:4000::/56",
@@ -87737,12 +88595,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3006::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d076:6000::/40",
       "region": "eu-north-1",
       "service": "EC2",
@@ -87815,6 +88667,30 @@
       "network_border_group": "ap-northeast-1"
     },
     {
+      "ipv6_prefix": "2606:f40:4903::/48",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a49::/60",
+      "region": "sa-east-1",
+      "service": "EC2",
+      "network_border_group": "sa-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4d::/60",
+      "region": "eu-south-2",
+      "service": "EC2",
+      "network_border_group": "eu-south-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f:4240::/60",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2a05:d016::/36",
       "region": "eu-north-1",
       "service": "EC2",
@@ -87876,12 +88752,6 @@
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:c300::/56",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3003:4000::/50",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -88007,6 +88877,12 @@
       "network_border_group": "us-east-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4d:4000::/60",
+      "region": "eu-west-1",
+      "service": "EC2",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b06:8000::/56",
       "region": "ap-south-1",
       "service": "EC2",
@@ -88127,12 +89003,6 @@
       "network_border_group": "sa-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3008::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d032:2000::/40",
       "region": "eu-west-3",
       "service": "EC2",
@@ -88188,6 +89058,12 @@
     },
     {
       "ipv6_prefix": "2606:f40:5000::/39",
+      "region": "eu-west-1",
+      "service": "EC2",
+      "network_border_group": "eu-west-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1b0d:4200::/56",
       "region": "eu-west-1",
       "service": "EC2",
       "network_border_group": "eu-west-1"
@@ -88305,18 +89181,6 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3007:c000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:1:107::/48",
-      "region": "ap-southeast-2",
-      "service": "EC2",
-      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2804:800:ff00::/48",
@@ -88487,12 +89351,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2631:1:10b::/48",
-      "region": "us-east-2",
-      "service": "EC2",
-      "network_border_group": "us-east-2"
-    },
-    {
       "ipv6_prefix": "2a05:d030:2000::/40",
       "region": "eu-west-3",
       "service": "EC2",
@@ -88607,7 +89465,19 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:f40:4901::/48",
+      "region": "eu-central-1",
+      "service": "EC2",
+      "network_border_group": "eu-central-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0f:c200::/56",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:3001:8000::/52",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -88635,6 +89505,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:e36::/48",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2404:c2c0:ef00::/40",
@@ -88683,18 +89559,6 @@
       "region": "us-east-2",
       "service": "EC2",
       "network_border_group": "us-east-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3001:c000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3005:c000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2406:daea:8800::/40",
@@ -88787,12 +89651,6 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3004:4000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d022::/36",
       "region": "eu-west-3",
       "service": "EC2",
@@ -88848,6 +89706,12 @@
     },
     {
       "ipv6_prefix": "2600:f0f0:0:21c::/62",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f3:f010:300::/56",
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
@@ -89123,12 +89987,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3006:8000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d031:2000::/40",
       "region": "eu-west-3",
       "service": "EC2",
@@ -89201,6 +90059,12 @@
       "network_border_group": "ca-central-1"
     },
     {
+      "ipv6_prefix": "2606:f40:4200::/40",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d068:800::/40",
       "region": "me-west-1",
       "service": "EC2",
@@ -89238,6 +90102,18 @@
     },
     {
       "ipv6_prefix": "2606:7b40:10ff:d280::/60",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4d:8340::/60",
+      "region": "eu-west-2",
+      "service": "EC2",
+      "network_border_group": "eu-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4f:c000::/60",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -89297,18 +90173,6 @@
       "network_border_group": "eu-central-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3004:c000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:0:1::/48",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d07d:6000::/40",
       "region": "eu-north-1",
       "service": "EC2",
@@ -89361,6 +90225,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4e::/60",
+      "region": "ca-central-1",
+      "service": "EC2",
+      "network_border_group": "ca-central-1"
     },
     {
       "ipv6_prefix": "2404:c2c0:3100::/40",
@@ -89621,6 +90491,12 @@
       "network_border_group": "ap-south-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a45:c000::/60",
+      "region": "ap-northeast-1",
+      "service": "EC2",
+      "network_border_group": "ap-northeast-1"
+    },
+    {
       "ipv6_prefix": "2a05:d05b:a000::/40",
       "region": "eu-south-1",
       "service": "EC2",
@@ -89687,12 +90563,6 @@
       "network_border_group": "ap-south-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3005::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d032:a000::/40",
       "region": "eu-south-1",
       "service": "EC2",
@@ -89721,6 +90591,12 @@
       "region": "eu-south-1",
       "service": "EC2",
       "network_border_group": "eu-south-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4e:4000::/60",
+      "region": "ca-west-1",
+      "service": "EC2",
+      "network_border_group": "ca-west-1"
     },
     {
       "ipv6_prefix": "2606:7b40:1b05:c100::/56",
@@ -89973,6 +90849,12 @@
       "region": "us-east-2",
       "service": "EC2",
       "network_border_group": "us-east-2"
+    },
+    {
+      "ipv6_prefix": "2600:f008:200::/40",
+      "region": "eu-south-2",
+      "service": "EC2",
+      "network_border_group": "eu-south-2"
     },
     {
       "ipv6_prefix": "2600:f0f1:41c0::/42",
@@ -90275,12 +91157,6 @@
       "network_border_group": "ap-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3006:4000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d06f:9000::/40",
       "region": "eu-central-2",
       "service": "EC2",
@@ -90533,10 +91409,22 @@
       "network_border_group": "eu-west-1"
     },
     {
+      "ipv6_prefix": "2600:f0f0:7::/48",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:e1f::/48",
       "region": "me-south-1",
       "service": "EC2",
       "network_border_group": "me-south-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0fb:c001::/56",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:f40:5800::/40",
@@ -90647,6 +91535,12 @@
       "network_border_group": "us-west-2-wl1-den-wlz-1"
     },
     {
+      "ipv6_prefix": "2600:f008:400::/40",
+      "region": "eu-west-1",
+      "service": "EC2",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2600:f00e::/39",
       "region": "eu-west-1",
       "service": "EC2",
@@ -90663,12 +91557,6 @@
       "region": "eu-central-1",
       "service": "EC2",
       "network_border_group": "eu-central-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3007:8000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d073:1000::/40",
@@ -90983,6 +91871,12 @@
       "network_border_group": "ap-southeast-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4d:c340::/60",
+      "region": "eu-west-3",
+      "service": "EC2",
+      "network_border_group": "eu-west-3"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0f:fd00::/56",
       "region": "us-west-2",
       "service": "EC2",
@@ -91049,16 +91943,10 @@
       "network_border_group": "us-west-2-phx-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3004::/50",
+      "ipv6_prefix": "2606:7b40:1a4f:c340::/60",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2631:1:10f::/48",
-      "region": "eu-west-3",
-      "service": "EC2",
-      "network_border_group": "eu-west-3"
     },
     {
       "ipv6_prefix": "2406:da33:b000::/40",
@@ -91161,6 +92049,12 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1-chi-1"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4600::/40",
+      "region": "eu-south-2",
+      "service": "EC2",
+      "network_border_group": "eu-south-2"
     },
     {
       "ipv6_prefix": "2606:7b40:1a2f:c200::/60",
@@ -91301,6 +92195,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4f:4000::/60",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2406:daeb:b000::/40",
       "region": "ap-south-2",
       "service": "EC2",
@@ -91377,6 +92277,12 @@
       "region": "ap-northeast-2",
       "service": "EC2",
       "network_border_group": "ap-northeast-2"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4300::/40",
+      "region": "eu-central-1",
+      "service": "EC2",
+      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2606:7b40:a3e:c00::/54",
@@ -91547,12 +92453,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3000:4000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d031:a000::/40",
       "region": "eu-south-1",
       "service": "EC2",
@@ -91716,12 +92616,6 @@
     },
     {
       "ipv6_prefix": "2606:7b40:10ff:ff00::/56",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3003:c000::/50",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -92213,6 +93107,12 @@
       "network_border_group": "ap-northeast-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:3009:c000::/52",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d070:6000::/40",
       "region": "eu-north-1",
       "service": "EC2",
@@ -92255,10 +93155,10 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3002:8000::/50",
-      "region": "us-west-2",
+      "ipv6_prefix": "2600:f0fb:c002::/56",
+      "region": "us-east-1",
       "service": "EC2",
-      "network_border_group": "us-west-2"
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2400:7fc0:ef00::/40",
@@ -92301,12 +93201,6 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:10d::/48",
-      "region": "eu-west-2",
-      "service": "EC2",
-      "network_border_group": "eu-west-2"
     },
     {
       "ipv6_prefix": "2a05:d040:4000::/40",
@@ -92484,6 +93378,18 @@
     },
     {
       "ipv6_prefix": "2600:f0fb:8000::/40",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a3f:4240::/60",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:3002::/56",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -92711,10 +93617,16 @@
       "network_border_group": "us-west-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3007::/50",
+      "ipv6_prefix": "2606:7b40:1a3f:c340::/60",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a4c::/60",
+      "region": "eu-central-1",
+      "service": "EC2",
+      "network_border_group": "eu-central-1"
     },
     {
       "ipv6_prefix": "2a05:d06f:b000::/40",
@@ -92915,12 +93827,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3001:8000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2400:7fc0:f300::/40",
       "region": "cn-north-1",
       "service": "EC2",
@@ -93071,12 +93977,6 @@
       "network_border_group": "ap-northeast-2"
     },
     {
-      "ipv6_prefix": "2606:7b40:3003::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2406:da30:1000::/40",
       "region": "af-south-1",
       "service": "EC2",
@@ -93129,6 +94029,12 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1b07:200::/56",
+      "region": "ap-southeast-1",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-1"
     },
     {
       "ipv6_prefix": "2406:da36:4800::/40",
@@ -93305,10 +94211,10 @@
       "network_border_group": "ap-southeast-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3005:8000::/50",
-      "region": "us-west-2",
+      "ipv6_prefix": "2606:7b40:1a47:4340::/60",
+      "region": "ap-southeast-2",
       "service": "EC2",
-      "network_border_group": "us-west-2"
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2620:107:4004::/48",
@@ -93417,12 +94323,6 @@
       "region": "eu-south-1",
       "service": "EC2",
       "network_border_group": "eu-south-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3007:4000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d068:4000::/40",
@@ -93639,6 +94539,12 @@
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:e37::/48",
+      "region": "ap-southeast-2",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:5402::/48",
@@ -93879,6 +94785,12 @@
       "region": "eu-central-1",
       "service": "EC2",
       "network_border_group": "eu-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0f0:5409::/48",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2600:f0f0:c004::/48",
@@ -94223,12 +95135,6 @@
       "network_border_group": "ap-northeast-1"
     },
     {
-      "ipv6_prefix": "2606:7b40:3001:4000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2406:da70:2000::/40",
       "region": "ap-northeast-2",
       "service": "EC2",
@@ -94281,12 +95187,6 @@
       "region": "ca-west-1",
       "service": "EC2",
       "network_border_group": "ca-west-1"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3006:c000::/50",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2606:7b40:f000:1600::/56",
@@ -94349,6 +95249,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4f:340::/60",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b00:700::/56",
       "region": "us-west-2",
       "service": "EC2",
@@ -94389,6 +95295,12 @@
       "region": "us-east-1",
       "service": "EC2",
       "network_border_group": "us-east-1"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4900::/48",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2a05:d072:1000::/40",
@@ -94487,6 +95399,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a46:c000::/60",
+      "region": "ap-south-2",
+      "service": "EC2",
+      "network_border_group": "ap-south-2"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b09:200::/56",
       "region": "sa-east-1",
       "service": "EC2",
@@ -94575,6 +95493,12 @@
       "region": "us-gov-east-1",
       "service": "EC2",
       "network_border_group": "us-gov-east-1"
+    },
+    {
+      "ipv6_prefix": "2600:f0fb:c800::/56",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:7b40:a3e:280::/60",
@@ -94739,12 +95663,6 @@
       "network_border_group": "us-east-2"
     },
     {
-      "ipv6_prefix": "2631::/48",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2a05:d03a:9000::/40",
       "region": "eu-central-2",
       "service": "EC2",
@@ -94785,6 +95703,12 @@
       "region": "us-east-2",
       "service": "EC2",
       "network_border_group": "us-east-2"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:3000:8000::/52",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
     },
     {
       "ipv6_prefix": "2001:3fc5:2000::/40",
@@ -94851,12 +95775,6 @@
       "region": "us-gov-west-1",
       "service": "EC2",
       "network_border_group": "us-gov-west-1"
-    },
-    {
-      "ipv6_prefix": "2631:1:101::/48",
-      "region": "eu-west-1",
-      "service": "EC2",
-      "network_border_group": "eu-west-1"
     },
     {
       "ipv6_prefix": "2406:dae9:8800::/40",
@@ -95009,12 +95927,6 @@
       "network_border_group": "us-east-1"
     },
     {
-      "ipv6_prefix": "2631:1:200::/40",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
       "ipv6_prefix": "2406:da32:9000::/40",
       "region": "ap-southeast-3",
       "service": "EC2",
@@ -95031,6 +95943,12 @@
       "region": "ap-southeast-4",
       "service": "EC2",
       "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ipv6_prefix": "2600:1f12:2000::/36",
+      "region": "us-south-1",
+      "service": "EC2",
+      "network_border_group": "us-south-1"
     },
     {
       "ipv6_prefix": "2600:1fba:4000::/39",
@@ -95061,6 +95979,12 @@
       "region": "eu-west-1",
       "service": "EC2",
       "network_border_group": "eu-west-1"
+    },
+    {
+      "ipv6_prefix": "2606:7b40:1a47:c000::/60",
+      "region": "ap-southeast-4",
+      "service": "EC2",
+      "network_border_group": "ap-southeast-4"
     },
     {
       "ipv6_prefix": "2606:7b40:1b0d:c100::/56",
@@ -95109,6 +96033,12 @@
       "region": "ap-southeast-2",
       "service": "EC2",
       "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ipv6_prefix": "2606:f40:4700::/40",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2a05:d06f:6000::/40",
@@ -95279,10 +96209,10 @@
       "network_border_group": "eu-west-3"
     },
     {
-      "ipv6_prefix": "2606:7b40:3001::/50",
-      "region": "us-west-2",
+      "ipv6_prefix": "2606:f40:4904::/48",
+      "region": "eu-west-1",
       "service": "EC2",
-      "network_border_group": "us-west-2"
+      "network_border_group": "eu-west-1"
     },
     {
       "ipv6_prefix": "2a05:d010:8000::/36",
@@ -95303,6 +96233,12 @@
       "network_border_group": "ca-west-1"
     },
     {
+      "ipv6_prefix": "2600:f008::/40",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2600:f0f0:8185::/48",
       "region": "ap-southeast-2",
       "service": "EC2",
@@ -95315,10 +96251,10 @@
       "network_border_group": "ap-northeast-3"
     },
     {
-      "ipv6_prefix": "2631:1:105::/48",
-      "region": "us-west-2",
+      "ipv6_prefix": "2606:7b40:1a4d:8000::/60",
+      "region": "eu-west-2",
       "service": "EC2",
-      "network_border_group": "us-west-2"
+      "network_border_group": "eu-west-2"
     },
     {
       "ipv6_prefix": "2600:1f29:8000::/36",
@@ -95442,12 +96378,6 @@
     },
     {
       "ipv6_prefix": "2606:7b40:1b0f:f800::/56",
-      "region": "us-west-2",
-      "service": "EC2",
-      "network_border_group": "us-west-2"
-    },
-    {
-      "ipv6_prefix": "2606:7b40:3000:c000::/50",
       "region": "us-west-2",
       "service": "EC2",
       "network_border_group": "us-west-2"
@@ -95747,6 +96677,12 @@
       "network_border_group": "eu-south-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a2f:c340::/60",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2a05:d03a:c000::/40",
       "region": "eu-west-2",
       "service": "EC2",
@@ -96011,6 +96947,12 @@
       "network_border_group": "eu-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a4d:4340::/60",
+      "region": "eu-west-1",
+      "service": "EC2",
+      "network_border_group": "eu-west-1"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0d:8000::/56",
       "region": "eu-west-2",
       "service": "EC2",
@@ -96057,6 +96999,12 @@
       "region": "ap-northeast-1",
       "service": "EC2",
       "network_border_group": "ap-northeast-1"
+    },
+    {
+      "ipv6_prefix": "2600:f008:300::/40",
+      "region": "us-east-1",
+      "service": "EC2",
+      "network_border_group": "us-east-1"
     },
     {
       "ipv6_prefix": "2606:f40:8800::/40",
@@ -96149,6 +97097,12 @@
       "network_border_group": "us-west-2"
     },
     {
+      "ipv6_prefix": "2606:7b40:1a2f:c240::/60",
+      "region": "us-west-2",
+      "service": "EC2",
+      "network_border_group": "us-west-2"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0f:f300::/56",
       "region": "us-west-2",
       "service": "EC2",
@@ -96233,6 +97187,12 @@
       "network_border_group": "sa-east-1"
     },
     {
+      "ipv6_prefix": "2606:7b40:10f4:3240::/60",
+      "region": "us-east-2",
+      "service": "EC2",
+      "network_border_group": "us-east-2"
+    },
+    {
       "ipv6_prefix": "2606:7b40:1b0f:600::/56",
       "region": "us-east-1",
       "service": "EC2",
@@ -96251,13 +97211,37 @@
       "network_border_group": "eu-north-1"
     },
     {
+      "ipv6_prefix": "2600:9000:de0::/43",
+      "region": "GLOBAL",
+      "service": "ROUTE53",
+      "network_border_group": "GLOBAL"
+    },
+    {
+      "ipv6_prefix": "2600:9000:ff8::/46",
+      "region": "GLOBAL",
+      "service": "ROUTE53",
+      "network_border_group": "GLOBAL"
+    },
+    {
       "ipv6_prefix": "2600:9000:f530::/46",
       "region": "GLOBAL",
       "service": "ROUTE53",
       "network_border_group": "GLOBAL"
     },
     {
+      "ipv6_prefix": "2600:9000:fc0::/43",
+      "region": "GLOBAL",
+      "service": "ROUTE53",
+      "network_border_group": "GLOBAL"
+    },
+    {
       "ipv6_prefix": "2600:9000:5300::/45",
+      "region": "GLOBAL",
+      "service": "ROUTE53",
+      "network_border_group": "GLOBAL"
+    },
+    {
+      "ipv6_prefix": "2600:9000:7000::/36",
       "region": "GLOBAL",
       "service": "ROUTE53",
       "network_border_group": "GLOBAL"
@@ -97203,6 +98187,108 @@
       "region": "us-west-2",
       "service": "AURORA_DSQL",
       "network_border_group": "us-west-2"
+    },
+    {
+      "ipv6_prefix": "2406:da1e:5ac:e700::/56",
+      "region": "ap-east-1",
+      "service": "EFS",
+      "network_border_group": "ap-east-1"
+    },
+    {
+      "ipv6_prefix": "2406:da1c:80f0:7500::/56",
+      "region": "ap-east-2",
+      "service": "EFS",
+      "network_border_group": "ap-east-2"
+    },
+    {
+      "ipv6_prefix": "2406:da12:ab7:7200::/56",
+      "region": "ap-northeast-2",
+      "service": "EFS",
+      "network_border_group": "ap-northeast-2"
+    },
+    {
+      "ipv6_prefix": "2406:da1b:9a2:5600::/56",
+      "region": "ap-south-2",
+      "service": "EFS",
+      "network_border_group": "ap-south-2"
+    },
+    {
+      "ipv6_prefix": "2406:da1c:410:4900::/56",
+      "region": "ap-southeast-2",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-2"
+    },
+    {
+      "ipv6_prefix": "2406:da1f:b03:cb00::/56",
+      "region": "ap-southeast-4",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-4"
+    },
+    {
+      "ipv6_prefix": "2406:da10:83d4:d000::/56",
+      "region": "ap-southeast-5",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-5"
+    },
+    {
+      "ipv6_prefix": "2406:da12:80a1:3d00::/56",
+      "region": "ap-southeast-6",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-6"
+    },
+    {
+      "ipv6_prefix": "2406:da14:8ad5:f500::/56",
+      "region": "ap-southeast-7",
+      "service": "EFS",
+      "network_border_group": "ap-southeast-7"
+    },
+    {
+      "ipv6_prefix": "2600:1f1a:4bd9:d100::/56",
+      "region": "ca-west-1",
+      "service": "EFS",
+      "network_border_group": "ca-west-1"
+    },
+    {
+      "ipv6_prefix": "2a05:d019:84f:800::/56",
+      "region": "eu-central-2",
+      "service": "EFS",
+      "network_border_group": "eu-central-2"
+    },
+    {
+      "ipv6_prefix": "2a05:d01a:eae:1b00::/56",
+      "region": "eu-south-1",
+      "service": "EFS",
+      "network_border_group": "eu-south-1"
+    },
+    {
+      "ipv6_prefix": "2a05:d011:fbb:2500::/56",
+      "region": "eu-south-2",
+      "service": "EFS",
+      "network_border_group": "eu-south-2"
+    },
+    {
+      "ipv6_prefix": "2a05:d018:548:fb00::/56",
+      "region": "eu-west-1",
+      "service": "EFS",
+      "network_border_group": "eu-west-1"
+    },
+    {
+      "ipv6_prefix": "2a05:d025:4c1:4700::/56",
+      "region": "il-central-1",
+      "service": "EFS",
+      "network_border_group": "il-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f17:4ce9:6400::/56",
+      "region": "mx-central-1",
+      "service": "EFS",
+      "network_border_group": "mx-central-1"
+    },
+    {
+      "ipv6_prefix": "2600:1f18:1be8:8f00::/56",
+      "region": "us-east-1",
+      "service": "EFS",
+      "network_border_group": "us-east-1"
     }
   ]
 }

--- a/lib/action_pack/cloudfront/version.rb
+++ b/lib/action_pack/cloudfront/version.rb
@@ -1,5 +1,5 @@
 module ActionPack
   module Cloudfront
-    VERSION = '1.2.17'.freeze
+    VERSION = '1.2.18'.freeze
   end
 end


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_

AWS periodically publishes updates to the IP address ranges used by CloudFront. This gem ships those ranges so that Rails apps can correctly identify and trust requests originating from CloudFront (e.g. resolving the real client IP behind the CDN). This change refreshes the bundled IP ranges to the latest published set (as of 2026-07-22) so consuming applications continue to recognize CloudFront traffic accurately.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_

This is a data-only refresh of the bundled CloudFront IP range list plus a version/changelog bump. No application logic changes.

- ✅ Negligible risk!

### Changes

- Regenerated `lib/action_pack/cloudfront/ip-ranges.json` with the latest CloudFront IP ranges published by AWS on 2026-07-22.
- Bumped the gem version from `1.2.17` to `1.2.18` in `lib/action_pack/cloudfront/version.rb`.
- Added a `v1.2.18` entry to `CHANGELOG.md` documenting the IP range update.

##### Updated Dependencies
 - None

### Project Link

[[LP-983](https://customink.monday.com/boards/12345/pulses/12345)](https://customink.atlassian.net/browse/LP-983)

### Screenshots

N/A — no visual changes.

### Notes

_Recommended reading: [Code Review guide](https://github.com/customink/guides/blob/master/operations/code-review/README.md)_

This is a routine data refresh. The bulk of the diff is the regenerated `ip-ranges.json`; the meaningful review surface is the version bump and changelog entry.

##### Library-Specific

- [x] Increment the changelog (CHANGELOG.md)
- [x] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github

[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository

##### Performance
- No new queries introduced; no indexing or time-boxing concerns.

[LP-983]: https://customink.atlassian.net/browse/LP-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ